### PR TITLE
Replace web3

### DIFF
--- a/coins/ethereum/Cargo.toml
+++ b/coins/ethereum/Cargo.toml
@@ -15,13 +15,13 @@ name = "walletd_ethereum"
 path = "src/lib.rs"
 
 
-web3 = { version = "0.18.0", optional = true, default-features = false, features = ["wasm", "http-rustls-tls"] }
 
 [dependencies]
 walletd_bip39 = {path = "../../mnemonics/bip39", version="0.2"}
 walletd_coin_core = {path = "../core/", version="0.2"}
 walletd_hd_key = {path = "../../mnemonics/hd_key", version="0.2"}
 
+web3 = { version = "0.18.0" }
 async-trait = "0.1.60"
 hex = "0.4.3"
 hex-literal = "0.3"
@@ -33,6 +33,6 @@ tiny-keccak = { version = "2.0.2" }
 zeroize = { version = "1.6.0", features = ["zeroize_derive"] }
 
 # for Ethereum
-ethers = { version = "2.0.6", features = ["rustls, ws, ipc"] }
+ethers = { version = "2", features = ["rustls", "ws", "ipc"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/coins/ethereum/Cargo.toml
+++ b/coins/ethereum/Cargo.toml
@@ -33,6 +33,6 @@ tiny-keccak = { version = "2.0.2" }
 zeroize = { version = "1.6.0", features = ["zeroize_derive"] }
 
 # for Ethereum
-ethers = { version = "2", features = ["rustls", "ws", "ipc"] }
+ethers = { version = "2.0.7", features = ["rustls", "ws", "ipc"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/coins/ethereum/Cargo.toml
+++ b/coins/ethereum/Cargo.toml
@@ -15,11 +15,6 @@ name = "walletd_ethereum"
 path = "src/lib.rs"
 
 
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["full"] }
-web3 = "0.18.0"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 web3 = { version = "0.18.0", optional = true, default-features = false, features = ["wasm", "http-rustls-tls"] }
 
 [dependencies]
@@ -37,4 +32,7 @@ thiserror = "1.0.38"
 tiny-keccak = { version = "2.0.2" }
 zeroize = { version = "1.6.0", features = ["zeroize_derive"] }
 
+# for Ethereum
+ethers = { version = "2.0.6", features = ["rustls, ws, ipc"] }
+tokio = { version = "1", features = ["full"] }
 

--- a/coins/ethereum/Cargo.toml
+++ b/coins/ethereum/Cargo.toml
@@ -21,7 +21,6 @@ walletd_bip39 = {path = "../../mnemonics/bip39", version="0.2"}
 walletd_coin_core = {path = "../core/", version="0.2"}
 walletd_hd_key = {path = "../../mnemonics/hd_key", version="0.2"}
 
-web3 = { version = "0.18.0" }
 async-trait = "0.1.60"
 hex = "0.4.3"
 hex-literal = "0.3"

--- a/coins/ethereum/examples/eth_quickstart_guide.rs
+++ b/coins/ethereum/examples/eth_quickstart_guide.rs
@@ -1,6 +1,6 @@
+use ethers::prelude::*;
 use walletd_ethereum::prelude::*;
 use walletd_hd_key::prelude::*;
-use ethers::prelude::*;
 
 const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
@@ -10,19 +10,19 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     let mut ethereum_wallet = EthereumWallet::builder()
         .master_hd_key(master_hd_key)
         .build()?;
-    
+
     let public_address = ethereum_wallet.public_address();
-    
+
     println!("ethereum wallet public address: {}", public_address);
-    
+
     assert!(ethereum_wallet.private_key().is_ok());
     assert!(ethereum_wallet.public_key().is_ok());
-    
+
     let derived_hd_key = ethereum_wallet.derived_hd_key()?;
     let private_key =
-            EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
+        EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
     let address_derivation_path = &derived_hd_key.derivation_path.clone();
-    
+
     // EthereumWallet stores the private key as a 32 byte array
     let secret_bytes = private_key.to_bytes();
 
@@ -33,10 +33,10 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     let wfbres = Wallet::from_bytes(&secret_bytes);
 
     let wfb = wfbres.unwrap();
-    // 5 = goerli chain id 
+    // 5 = goerli chain id
 
     // Link our wallet instance to our provider for signing our transactions
-    let client = SignerMiddleware::new(provider, wfb.with_chain_id(5u64));    
+    let client = SignerMiddleware::new(provider, wfb.with_chain_id(5u64));
 
     // Create a transaction request to send 10000 wei to the Goerli address
     let tx = TransactionRequest::new()
@@ -49,8 +49,15 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
 
     let pending_tx = client.send_transaction(tx, None).await.unwrap();
 
-    let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
-    let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
+    let receipt = pending_tx
+        .await
+        .unwrap()
+        .ok_or_else(|| println!("tx dropped from mempool"))
+        .unwrap();
+    let tx = client
+        .get_transaction(receipt.transaction_hash)
+        .await
+        .unwrap();
 
     println!("tx: {:?}", &tx);
 

--- a/coins/ethereum/examples/eth_quickstart_guide.rs
+++ b/coins/ethereum/examples/eth_quickstart_guide.rs
@@ -1,6 +1,9 @@
 use walletd_ethereum::prelude::*;
 use walletd_hd_key::prelude::*;
+use ethers::prelude::*;
 
+
+const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() -> Result<(), walletd_ethereum::Error> {
     let master_seed = Seed::from_str("a2fd9c0522d84d52ee4c8533dc02d4b69b4df9b6255e1af20c9f1d4d691689f2a38637eb1ec778972bf845c32d5ae83c7536999b5666397ac32021b21e0accee")?;
@@ -12,13 +15,58 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     println!("ethereum wallet public address: {}", public_address);
     assert!(ethereum_wallet.private_key().is_ok());
     assert!(ethereum_wallet.public_key().is_ok());
+    println!("{:?}", ethereum_wallet.private_key().unwrap());
     let derived_hd_key = ethereum_wallet.derived_hd_key()?;
+    let private_key =
+            EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
     let address_derivation_path = &derived_hd_key.derivation_path.clone();
     println!("address derivation path: {}", address_derivation_path);
+
+    let secret_bytes = private_key.to_bytes();
+
+    let provider = Provider::try_from(PROVIDER_URL).unwrap();
+    //println!("wfb: {:?}", wfb);
+    println!("secret key: {:?}", secret_bytes);
+
+    let secret_bytes_to_string = secret_bytes.to_ascii_lowercase();
+
+    println!("Over here: {:?}", secret_bytes_to_string);
+
+    let wfbres = Wallet::from_bytes(&secret_bytes);
+
+    let wfb = wfbres.unwrap();
+
+    println!("wfb: {:?}", &wfb);
+    //println!("provider: {:?}", &provider);
+
+    // 5 = goerli chain id 
+    let client = SignerMiddleware::new(provider, wfb.with_chain_id(5u64));
+    println!("client: {:?}", &client);
+
+    let tx = TransactionRequest::new()
+        .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
+        .gas(21000)
+        .value(10000)
+        .chain_id(5u64);
+
+    println!("tx: {:?}", &tx);
+
+    let pending_tx = client.send_transaction(tx, None).await.unwrap();
+
+    let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
+    let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
+
+    println!("tx: {:?}", &tx);
+
+
+
+
     assert_eq!(
         address_derivation_path.to_string(),
         "m/44'/60'/0'/0/0".to_string()
     );
+
+    // let lw: LocalWallet = secret_key.parse::<LocalWallet>()?;
 
     let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
     let eth_client = EthClient::new(ethclient_url)?;

--- a/coins/ethereum/examples/eth_quickstart_guide.rs
+++ b/coins/ethereum/examples/eth_quickstart_guide.rs
@@ -2,8 +2,6 @@ use walletd_ethereum::prelude::*;
 use walletd_hd_key::prelude::*;
 use ethers::prelude::*;
 
-
-//const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() -> Result<(), walletd_ethereum::Error> {
@@ -56,17 +54,12 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
 
     println!("tx: {:?}", &tx);
 
-
-
-
     assert_eq!(
         address_derivation_path.to_string(),
         "m/44'/60'/0'/0/0".to_string()
     );
 
-    // let lw: LocalWallet = secret_key.parse::<LocalWallet>()?;
-
-    let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+    let ethclient_url = PROVIDER_URL;
     let eth_client = EthClient::new(ethclient_url)?;
     let tx_hash = "0xe4216d69bf935587b82243e68189de7ade0aa5b6f70dd0de8636b8d643431c0b";
     let tx = eth_client.transaction_data_from_hash(tx_hash).await?;

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -4,15 +4,7 @@ use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
 use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
 use walletd_hd_key::HDNetworkType;
 
-
-use ethers::{
-    core::{types::TransactionRequest, utils::Anvil},
-    middleware::SignerMiddleware,
-    providers::{Http, Middleware, Provider},
-    signers::{LocalWallet, Signer},
-    types::Address
-};
-use std::convert::TryFrom;
+use ethers::prelude::*;
 
 const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
@@ -26,7 +18,7 @@ async fn main() -> () {
         .build()
         .unwrap();
     let eth_client = EthClient::new(PROVIDER_URL).unwrap();
-    let address: H160 = "00a329c0648769a73afac7f9381e08fb43dbea72".parse().unwrap();
+    let address: H160 = GOERLI_TEST_ADDRESS.parse().unwrap();
 
     let seed = restored_mnemonic.to_seed();
 
@@ -47,17 +39,18 @@ async fn main() -> () {
     let from: Address = wallet.public_address().as_str().parse().unwrap();
     print!("from: {:?}", &from);
     let balance = &blockchain_client.ethers().get_balance(from, None).await.unwrap();
-    print!("balance_before: {:?}", &balance_before);
+    print!("balance: {:?}", &balance);
+
+    let eth_amount: EthereumAmount = EthereumAmount::from_wei(*balance);
+    println!(
+        "ethereum wallet balance: {} ETH, ({} wei)",
+        eth_amount.eth(),
+        eth_amount.wei()
+    );
 
     // Not that we need to, but we can determine the nonce manually if we want
     let nonce= &blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
     print!("nonce: {:?}", &nonce);
-
-    println!(
-        "ethereum wallet balance: {} ETH, ({} wei)",
-        balance.eth(),
-        balance.wei()
-    );
 
     ()
 }

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -45,39 +45,24 @@ async fn main() -> () {
         .build()
         .unwrap();
 
-    // let wallet_lw: LocalWallet = LocalWallet::
-
-    // print!("{}", wallet_lw);
-
+    
     let from: Address = wallet.public_address().as_str().parse().unwrap();
     print!("from: {:?}", &from);
     let balance_before = &blockchain_client.ethers().get_balance(from, None).await.unwrap();
     print!("balance_before: {:?}", &balance_before);
+
+    // Not that we need to, but we can determine the nonce manually
     let nonce= &blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
     print!("nonce: {:?}", &nonce);
-    // wallet.set_blockchain_client(blockchain_client);
-    // // This example now assumes that the wallet has been funded with some testnet ETH
-    // println!("wallet: {:#?}", &wallet);
-
-    //println!("balance: {:?}", &wallet.balance().await.unwrap());
-
-    // let tx = TransactionRequest::new()
-    //     .to(GOERLI_TEST_ADDRESS)
-    //     .value(1000)
-    //     .from(from);
-    // let client = SignerMiddleware::new(blockchain_client.ethers(), 1);
+   
 
     let to: Address = GOERLI_TEST_ADDRESS.parse().unwrap();
     let tx = TransactionRequest::new().to(to).value(1000).from(from); // specify the `from` field so that the client knows which account to use
 
     let tx = blockchain_client.ethers().send_transaction(tx, None).await.unwrap().await.unwrap();
     
-    // Broadcast the tx to the mempool
-    //let txr = test.ethers().send_transaction(test, None).await.unwrap();
     println!("tx: {:?}", &tx);
-    
-    //println!("{}", serde_json::to_string(tx).unwrap());
-
+   
     let nonce2 = blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
     
     // let sa = ethers::types::U256::from(10000);

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -64,6 +64,9 @@ async fn main() -> () {
     println!("tx: {:?}", &tx);
    
     let nonce2 = blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
+    let mut ethereum_wallet = EthereumWallet::builder()
+        .master_hd_key(master_hd_key)
+        .build()?;
     
     // let sa = ethers::types::U256::from(10000);
     // let send_amount = EthereumAmount::from_wei(sa);

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -64,18 +64,16 @@ async fn main() -> () {
     println!("tx: {:?}", &tx);
    
     let nonce2 = blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
-    let mut ethereum_wallet = EthereumWallet::builder()
-        .master_hd_key(master_hd_key)
-        .build()?;
+    println!("nonce2: {:?}", &nonce2);
     
     // let sa = ethers::types::U256::from(10000);
     // let send_amount = EthereumAmount::from_wei(sa);
     //assert!(nonce < *nonce2);
 
-    let balance_after = blockchain_client.balance(from).await.unwrap();
+    // let balance_after = blockchain_client.balance(from).await.unwrap();
     //assert!(balance_after < balance_before);
 
-    println!("Balance before {balance_before}");
+    // println!("Balance before {balance_before}");
     // let tx_hash = wallet
     //     .transfer(&send_amount, GOERLI_TEST_ADDRESS)
     //     .await

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -11,7 +11,7 @@ const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 #[tokio::main]
 async fn main() {
     let mnemonic_phrase: &str =
-    "mandate rude write gather vivid inform leg swift usual early bamboo element";
+        "mandate rude write gather vivid inform leg swift usual early bamboo element";
     let restored_mnemonic = Bip39Mnemonic::builder()
         .mnemonic_phrase(mnemonic_phrase)
         .detect_language()
@@ -24,8 +24,7 @@ async fn main() {
 
     let _eth_client = EthClient::new(PROVIDER_URL);
 
-    let blockchain_client =
-        EthClient::new(PROVIDER_URL).unwrap();
+    let blockchain_client = EthClient::new(PROVIDER_URL).unwrap();
 
     println!("blockchain_client: {:?}", &blockchain_client);
 
@@ -35,10 +34,13 @@ async fn main() {
         .build()
         .unwrap();
 
-    
     let from: Address = wallet.public_address().as_str().parse().unwrap();
     print!("from: {:?}", &from);
-    let balance = &blockchain_client.ethers().get_balance(from, None).await.unwrap();
+    let balance = &blockchain_client
+        .ethers()
+        .get_balance(from, None)
+        .await
+        .unwrap();
     print!("balance: {:?}", &balance);
 
     let eth_amount: EthereumAmount = EthereumAmount::from_wei(*balance);
@@ -49,8 +51,10 @@ async fn main() {
     );
 
     // Not that we need to, but we can determine the nonce manually if we want
-    let nonce= &blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
+    let nonce = &blockchain_client
+        .ethers()
+        .get_transaction_count(from, None)
+        .await
+        .unwrap();
     print!("nonce: {:?}", &nonce);
-
-    
 }

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -1,6 +1,3 @@
-// EthereumAmount.new_from_eth(u64)
-// use std::str::FromStr;
-
 use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder};
 
 use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
@@ -15,8 +12,9 @@ use ethers::{
     signers::{LocalWallet, Signer},
     types::Address
 };
-//use eyre::Result;
 use std::convert::TryFrom;
+
+const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 #[tokio::main]
 async fn main() -> () {
@@ -27,15 +25,15 @@ async fn main() -> () {
         .detect_language()
         .build()
         .unwrap();
-    let eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
+    let eth_client = EthClient::new(PROVIDER_URL).unwrap();
     let address: H160 = "00a329c0648769a73afac7f9381e08fb43dbea72".parse().unwrap();
 
     let seed = restored_mnemonic.to_seed();
 
-    let _eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT);
+    let _eth_client = EthClient::new(PROVIDER_URL);
 
     let blockchain_client =
-        EthClient::new("https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161").unwrap();
+        EthClient::new(PROVIDER_URL).unwrap();
 
     println!("blockchain_client: {:?}", &blockchain_client);
 

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -1,6 +1,6 @@
 use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder};
 
-use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
+use walletd_coin_core::{BlockchainConnector, CryptoWalletBuilder};
 use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
 use walletd_hd_key::HDNetworkType;
 
@@ -9,7 +9,7 @@ use ethers::prelude::*;
 const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 #[tokio::main]
-async fn main() -> () {
+async fn main() {
     let mnemonic_phrase: &str =
     "mandate rude write gather vivid inform leg swift usual early bamboo element";
     let restored_mnemonic = Bip39Mnemonic::builder()
@@ -17,8 +17,8 @@ async fn main() -> () {
         .detect_language()
         .build()
         .unwrap();
-    let eth_client = EthClient::new(PROVIDER_URL).unwrap();
-    let address: H160 = GOERLI_TEST_ADDRESS.parse().unwrap();
+    let _eth_client = EthClient::new(PROVIDER_URL).unwrap();
+    let _address: H160 = GOERLI_TEST_ADDRESS.parse().unwrap();
 
     let seed = restored_mnemonic.to_seed();
 
@@ -29,7 +29,7 @@ async fn main() -> () {
 
     println!("blockchain_client: {:?}", &blockchain_client);
 
-    let mut wallet = EthereumWallet::builder()
+    let wallet = EthereumWallet::builder()
         .mnemonic_seed(seed)
         .network_type(HDNetworkType::TestNet)
         .build()
@@ -52,5 +52,5 @@ async fn main() -> () {
     let nonce= &blockchain_client.ethers().get_transaction_count(from, None).await.unwrap();
     print!("nonce: {:?}", &nonce);
 
-    ()
+    
 }

--- a/coins/ethereum/examples/get_accounts_and_balances.rs
+++ b/coins/ethereum/examples/get_accounts_and_balances.rs
@@ -1,6 +1,6 @@
 use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder};
 
-use walletd_coin_core::{BlockchainConnector, CryptoWalletBuilder};
+use walletd_coin_core::prelude::*;
 use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
 use walletd_hd_key::HDNetworkType;
 

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -4,8 +4,9 @@ pub const INFURA_GOERLI_ENDPOINT: &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
-use web3::types::U64;
+use ethers::types::U64;
 
+// Works with ethers
 #[tokio::main]
 async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc
@@ -15,5 +16,6 @@ async fn main() -> web3::Result<()> {
     let _latest_block_data = EthClient::latest_block(&eth_client).await.is_err();
 
     assert_eq!(_latest_block_data, false);
+    print!("If you see this, it means that block 8455626 was retrieved without error.");
     Ok(())
 }

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -4,11 +4,11 @@ const PROVIDER_URL: &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
-use ethers::types::U64;
+use ethers::prelude::*;
 
 // Works with ethers
 #[tokio::main]
-async fn main() -> web3::Result<()> {
+async fn main() {
     // Transport can be one of Http, WebSocket, Ipc
     let eth_client = EthClient::new(PROVIDER_URL).unwrap();
     let _block_number: U64 = U64::from(8455626);
@@ -17,5 +17,5 @@ async fn main() -> web3::Result<()> {
 
     assert!(!_latest_block_data);
     print!("If you see this, it means that block 8455626 was retrieved without error.");
-    Ok(())
+    ()
 }

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -1,6 +1,6 @@
 extern crate walletd_ethereum;
 // https://goerli.etherscan.io/block/8455626
-pub const PROVIDER_URL &str =
+const PROVIDER_URL: &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -1,10 +1,9 @@
 extern crate walletd_ethereum;
 // https://goerli.etherscan.io/block/8455626
-const PROVIDER_URL: &str =
-    "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+use ethers::prelude::*;
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
-use ethers::prelude::*;
 
 // Works with ethers
 #[tokio::main]
@@ -17,5 +16,4 @@ async fn main() {
 
     assert!(!_latest_block_data);
     print!("If you see this, it means that block 8455626 was retrieved without error.");
-    
 }

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -11,7 +11,9 @@ async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc
     let eth_client = EthClient::new(&INFURA_GOERLI_ENDPOINT.to_string()).unwrap();
     let _block_number: U64 = U64::from(8455626);
+    print!("block_number: {:?}", &_block_number);
+    let _latest_block_data = EthClient::latest_block(&eth_client).await.is_err();
 
-    let _latest_block_data = EthClient::latest_block(&eth_client);
+    assert_eq!(_latest_block_data, false);
     Ok(())
 }

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -1,6 +1,6 @@
 extern crate walletd_ethereum;
 // https://goerli.etherscan.io/block/8455626
-pub const INFURA_GOERLI_ENDPOINT: &str =
+pub const PROVIDER_URL &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
@@ -10,7 +10,7 @@ use ethers::types::U64;
 #[tokio::main]
 async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc
-    let eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
+    let eth_client = EthClient::new(PROVIDER_URL).unwrap();
     let _block_number: U64 = U64::from(8455626);
     print!("block_number: {:?}", &_block_number);
     let _latest_block_data = EthClient::latest_block(&eth_client).await.is_err();

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -17,5 +17,5 @@ async fn main() {
 
     assert!(!_latest_block_data);
     print!("If you see this, it means that block 8455626 was retrieved without error.");
-    ()
+    
 }

--- a/coins/ethereum/examples/get_block_data.rs
+++ b/coins/ethereum/examples/get_block_data.rs
@@ -10,12 +10,12 @@ use ethers::types::U64;
 #[tokio::main]
 async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc
-    let eth_client = EthClient::new(&INFURA_GOERLI_ENDPOINT.to_string()).unwrap();
+    let eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
     let _block_number: U64 = U64::from(8455626);
     print!("block_number: {:?}", &_block_number);
     let _latest_block_data = EthClient::latest_block(&eth_client).await.is_err();
 
-    assert_eq!(_latest_block_data, false);
+    assert!(!_latest_block_data);
     print!("If you see this, it means that block 8455626 was retrieved without error.");
     Ok(())
 }

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -1,8 +1,7 @@
 extern crate walletd_ethereum;
 // https://goerli.etherscan.io/block/8455626
 
-pub const PROVIDER_URL: &str =
-    "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+pub const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
 
@@ -14,13 +13,14 @@ async fn main() {
     let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
     let eth_client = EthClient::new(ethclient_url).unwrap();
     let tx_hash = "0xe4216d69bf935587b82243e68189de7ade0aa5b6f70dd0de8636b8d643431c0b";
-    let tx = eth_client.transaction_data_from_hash(tx_hash).await.unwrap();
+    let tx = eth_client
+        .transaction_data_from_hash(tx_hash)
+        .await
+        .unwrap();
     let block_number = eth_client.current_block_number().await;
     let gas_price = eth_client.gas_price().await;
 
     println!("Latest block number: {:#?}", block_number);
     println!("Gas price: {:#?}", gas_price);
     println!("transaction data: {:?}", tx);
-
-    
 }

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -6,6 +6,7 @@ pub const INFURA_GOERLI_ENDPOINT: &str =
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
 
+// Works with ethers.js
 #[tokio::main]
 async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -1,29 +1,26 @@
 extern crate walletd_ethereum;
 // https://goerli.etherscan.io/block/8455626
 
-pub const INFURA_GOERLI_ENDPOINT: &str =
+pub const PROVIDER_URL &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
 
-// Works with ethers.js
 #[tokio::main]
-async fn main() -> web3::Result<()> {
+async fn main() {
     // Transport can be one of Http, WebSocket, Ipc
-    // let transport = web3::transports::Http::new(INFURA_GOERLI_ENDPOINT)?;
+    // let transport = web3::transports::Http::new(PROVIDER_URL)?;
 
     let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-    let eth_client = EthClient::new(ethclient_url)?;
+    let eth_client = EthClient::new(ethclient_url).unwrap();
     let tx_hash = "0xe4216d69bf935587b82243e68189de7ade0aa5b6f70dd0de8636b8d643431c0b";
-    let tx = eth_client.transaction_data_from_hash(tx_hash).await?;
+    let tx = eth_client.transaction_data_from_hash(tx_hash).await.unwrap();
     let block_number = eth_client.current_block_number().await;
     let gas_price = eth_client.gas_price().await;
-    let balance = ethereum_wallet.balance().await?;
 
-    println!("Block number: {:#?}", block_number);
+    println!("Latest block number: {:#?}", block_number);
     println!("Gas price: {:#?}", gas_price);
     println!("transaction data: {:?}", tx);
-    //ethereum_wallet.set_blockchain_client(eth_client);
-    
-    Ok(())
+
+    ()
 }

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -1,7 +1,7 @@
 extern crate walletd_ethereum;
 // https://goerli.etherscan.io/block/8455626
 
-pub const PROVIDER_URL &str =
+pub const PROVIDER_URL: &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -11,7 +11,7 @@ use walletd_ethereum::EthClient;
 async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc
     // let transport = web3::transports::Http::new(INFURA_GOERLI_ENDPOINT)?;
-    let eth_client = EthClient::new(&INFURA_GOERLI_ENDPOINT.to_string()).unwrap();
+    let eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
 
     let block_number = eth_client.current_block_number().await;
     let gas_price = eth_client.gas_price().await;

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -22,5 +22,5 @@ async fn main() {
     println!("Gas price: {:#?}", gas_price);
     println!("transaction data: {:?}", tx);
 
-    ()
+    
 }

--- a/coins/ethereum/examples/get_network_information.rs
+++ b/coins/ethereum/examples/get_network_information.rs
@@ -11,13 +11,19 @@ use walletd_ethereum::EthClient;
 async fn main() -> web3::Result<()> {
     // Transport can be one of Http, WebSocket, Ipc
     // let transport = web3::transports::Http::new(INFURA_GOERLI_ENDPOINT)?;
-    let eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
 
+    let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+    let eth_client = EthClient::new(ethclient_url)?;
+    let tx_hash = "0xe4216d69bf935587b82243e68189de7ade0aa5b6f70dd0de8636b8d643431c0b";
+    let tx = eth_client.transaction_data_from_hash(tx_hash).await?;
     let block_number = eth_client.current_block_number().await;
     let gas_price = eth_client.gas_price().await;
+    let balance = ethereum_wallet.balance().await?;
 
     println!("Block number: {:#?}", block_number);
     println!("Gas price: {:#?}", gas_price);
-
+    println!("transaction data: {:?}", tx);
+    //ethereum_wallet.set_blockchain_client(eth_client);
+    
     Ok(())
 }

--- a/coins/ethereum/examples/get_smart_contract_transactions.rs
+++ b/coins/ethereum/examples/get_smart_contract_transactions.rs
@@ -17,7 +17,7 @@ pub const INFURA_GOERLI_ENDPOINT: &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() {
-    let _eth_client = EthClient::new(&INFURA_GOERLI_ENDPOINT.to_string()).unwrap();
+    let _eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
     let _bn = "8455626";
     //     //let block_data = EthClient::block_data_from_numeric_string(&eth_client, &bn)
     //         .await

--- a/coins/ethereum/examples/get_smart_contract_transactions.rs
+++ b/coins/ethereum/examples/get_smart_contract_transactions.rs
@@ -13,7 +13,7 @@
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
 
-pub const PROVIDER_URL &str =
+pub const PROVIDER_URL: &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() {

--- a/coins/ethereum/examples/get_smart_contract_transactions.rs
+++ b/coins/ethereum/examples/get_smart_contract_transactions.rs
@@ -13,8 +13,7 @@
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
 
-pub const PROVIDER_URL: &str =
-    "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+pub const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() {
     let _eth_client = EthClient::new(PROVIDER_URL).unwrap();

--- a/coins/ethereum/examples/get_smart_contract_transactions.rs
+++ b/coins/ethereum/examples/get_smart_contract_transactions.rs
@@ -13,11 +13,11 @@
 use walletd_coin_core::BlockchainConnector;
 use walletd_ethereum::EthClient;
 
-pub const INFURA_GOERLI_ENDPOINT: &str =
+pub const PROVIDER_URL &str =
     "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() {
-    let _eth_client = EthClient::new(INFURA_GOERLI_ENDPOINT).unwrap();
+    let _eth_client = EthClient::new(PROVIDER_URL).unwrap();
     let _bn = "8455626";
     //     //let block_data = EthClient::block_data_from_numeric_string(&eth_client, &bn)
     //         .await

--- a/coins/ethereum/examples/instantiate_wallet.rs
+++ b/coins/ethereum/examples/instantiate_wallet.rs
@@ -20,14 +20,10 @@ async fn main() -> web3::Result<()> {
 
     println!("seed as bytes: {:?}", seed.as_bytes());
 
-    let wallet = match EthereumWallet::builder()
+    let wallet = EthereumWallet::builder()
         .mnemonic_seed(seed)
         .network_type(HDNetworkType::TestNet)
-        .build()
-    {
-        Ok(wallet) => Ok(wallet),
-        Err(e) => Err(e),
-    };
+        .build();
 
     println!("wallet: {:?}", &wallet);
     Ok(())

--- a/coins/ethereum/examples/instantiate_wallet.rs
+++ b/coins/ethereum/examples/instantiate_wallet.rs
@@ -22,5 +22,5 @@ async fn main() {
         .build();
 
     println!("wallet: {:?}", &wallet);
-    ()
+    
 }

--- a/coins/ethereum/examples/instantiate_wallet.rs
+++ b/coins/ethereum/examples/instantiate_wallet.rs
@@ -4,8 +4,6 @@ use walletd_bip39::{Bip39Language, Bip39Mnemonic, Mnemonic};
 use walletd_ethereum::EthereumWallet;
 use walletd_hd_key::HDNetworkType;
 
-// const GOERLI_TEST_ADDRESS: &str =
-// "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 #[tokio::main]
 async fn main() -> web3::Result<()> {
     // main_wip()?;

--- a/coins/ethereum/examples/instantiate_wallet.rs
+++ b/coins/ethereum/examples/instantiate_wallet.rs
@@ -6,7 +6,6 @@ use walletd_hd_key::HDNetworkType;
 
 #[tokio::main]
 async fn main() {
-
     let mnemonic_phrase: &str =
         "outer ride neither foil glue number place usage ball shed dry point";
     let passphrase: Option<&str> = Some("mypassphrase");
@@ -22,5 +21,4 @@ async fn main() {
         .build();
 
     println!("wallet: {:?}", &wallet);
-    
 }

--- a/coins/ethereum/examples/instantiate_wallet.rs
+++ b/coins/ethereum/examples/instantiate_wallet.rs
@@ -5,8 +5,7 @@ use walletd_ethereum::EthereumWallet;
 use walletd_hd_key::HDNetworkType;
 
 #[tokio::main]
-async fn main() -> web3::Result<()> {
-    // main_wip()?;
+async fn main() {
 
     let mnemonic_phrase: &str =
         "outer ride neither foil glue number place usage ball shed dry point";
@@ -23,5 +22,5 @@ async fn main() -> web3::Result<()> {
         .build();
 
     println!("wallet: {:?}", &wallet);
-    Ok(())
+    ()
 }

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -39,7 +39,7 @@ async fn main() {
     // let provider = Provider::<Http>::connect(PROV_URL).await.unwrap();
     
     let phrase = "mandate rude write gather vivid inform leg swift usual early bamboo element";
-    let index = 1u32; // The wallet number's index
+    let index = 0u32; // The wallet number's index
 
     let provider = Provider::try_from(PROV_URL).unwrap();
 
@@ -53,11 +53,11 @@ async fn main() {
     println!("provider: {:?}", &provider);
 
     // 5 = goerli chain id
-    let client = SignerMiddleware::new(provider, wallet_nonlocal);
+    let client = SignerMiddleware::new(provider, wallet_nonlocal.with_chain_id(5u64));
 
     let tx = TransactionRequest::new()
-        .to("vitalik.eth")
-        .chain_id(5u64)
+        .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
+        .gas(21000)
         .value(10000);
     
     

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -1,12 +1,12 @@
 // EthereumAmount.new_from_eth(u64)
 // use std::str::FromStr;
 
-use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder as oldMnemonicBuilder};
-// use web3::types::U256;
+// use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder as oldMnemonicBuilder};
+// // use web3::types::U256;
 
-use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
-use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
-use walletd_hd_key::HDNetworkType;
+// use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
+// use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
+// use walletd_hd_key::HDNetworkType;
 
 // use ethers::signers::{LocalWallet, Signer};
 // use ethers::middleware::{gas_oracle::GasNow, MiddlewareBuilder};
@@ -23,26 +23,26 @@ use walletd_hd_key::HDNetworkType;
 // };
 
 use ethers::{
-    core::{types::TransactionRequest, utils::Anvil},
+    core::{types::TransactionRequest},
     middleware::SignerMiddleware,
-    providers::{Http, Middleware, Provider},
-    signers::{LocalWallet, Signer},
+    providers::{Middleware, Provider},
+    signers::{Signer},
     signers::{coins_bip39::English, MnemonicBuilder},
 };
 
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
-const PROV_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() {
-    // main_wip()?;
+   
+    let phrase = "mandate rude write gather vivid inform leg swift usual early bamboo element"; 
+    let index = 0u32; // The wallet number's index. Indexes in Ethereum start at 0.
 
-    // let provider = Provider::<Http>::connect(PROV_URL).await.unwrap();
-    
-    let phrase = "mandate rude write gather vivid inform leg swift usual early bamboo element";
-    let index = 0u32; // The wallet number's index
+    // Initialise a provider from a URL
+    // TODO: this should be handled by our EthClient instead of directly calling ethers
+    let provider = Provider::try_from(PROVIDER_URL).unwrap();
 
-    let provider = Provider::try_from(PROV_URL).unwrap();
-
+    // Initialise a wallet using the Mnemonic Builder (We need to switch this to our facade at some stage)
     let wallet_nonlocal = MnemonicBuilder::<English>::default()
         .phrase(phrase)
         .index(index)
@@ -52,74 +52,18 @@ async fn main() {
 
     println!("provider: {:?}", &provider);
 
-    // 5 = goerli chain id
+    // 5 = goerli chain id 
     let client = SignerMiddleware::new(provider, wallet_nonlocal.with_chain_id(5u64));
 
     let tx = TransactionRequest::new()
         .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
         .gas(21000)
         .value(10000);
-    
-    
-
+     
     let pending_tx = client.send_transaction(tx, None).await.unwrap();
 
     let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
     let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
     
     println!("tx: {:?}", &tx);
-
-    //let wallet: LocalWallet = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc".parse();
-
-    //let mut client = SignerMiddleware::new(provider, wallet);
-
-
-    // Access mnemonic phrase with password
-    // Child key at derivation path: m/44'/60'/0'/0/{index}
-    // let wallet: LocalWallet = MnemonicBuilder::<English>::default()
-    //     .phrase(phrase)
-    //     .index(index)?
-    //     // Use this if your mnemonic is encrypted
-    //     .build()?;
-
-    // let mnemonic_phrase: &str =
-    //     "mandate rude write gather vivid inform leg swift usual early bamboo element";
-    // let restored_mnemonic = Bip39Mnemonic::builder()
-    //     .mnemonic_phrase(mnemonic_phrase)
-    //     .detect_language()
-    //     .build()
-    //     .unwrap();
-
-    // let seed = restored_mnemonic.to_seed();
-
-    // println!("seed as bytes: {:?}", seed.as_bytes());
-
-    // let blockchain_client =
-    //     EthClient::new("https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161").unwrap();
-
-    // println!("blockchain_client: {:?}", &blockchain_client);
-
-    // let mut wallet = EthereumWallet::builder()
-    //     .mnemonic_seed(seed)
-    //     .network_type(HDNetworkType::TestNet)
-    //     .build()
-    //     .unwrap();
-    // wallet.set_blockchain_client(blockchain_client);
-    // // This example now assumes that the wallet has been funded with some testnet ETH
-    // println!("wallet: {:#?}", &wallet);
-
-    // println!("balance: {:?}", &wallet.balance().await.unwrap());
-
-    // let sa = ethers::types::U256::from(10000);
-    // let send_amount = EthereumAmount::from_wei(sa);
-
-    // println!("send_amount: {:?}", &send_amount);
-
-
-    // let tx_hash = wallet
-    //     .transfer(&send_amount, GOERLI_TEST_ADDRESS)
-    //     .await
-    //     .unwrap();
-
-    // println!("tx_hash: 0x{}", &tx_hash);
 }

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -39,7 +39,7 @@ async fn main() {
     // let provider = Provider::<Http>::connect(PROV_URL).await.unwrap();
     
     let phrase = "mandate rude write gather vivid inform leg swift usual early bamboo element";
-    let index = 0u32;
+    let index = 1u32; // The wallet number's index
 
     let provider = Provider::try_from(PROV_URL).unwrap();
 
@@ -57,8 +57,11 @@ async fn main() {
 
     let tx = TransactionRequest::new()
         .to("vitalik.eth")
+        .chain_id(5u64)
         .value(10000);
     
+    
+
     let pending_tx = client.send_transaction(tx, None).await.unwrap();
 
     let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -8,7 +8,7 @@ const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 async fn main() -> Result<(), walletd_ethereum::Error> {
     let master_seed = Seed::from_str("a2fd9c0522d84d52ee4c8533dc02d4b69b4df9b6255e1af20c9f1d4d691689f2a38637eb1ec778972bf845c32d5ae83c7536999b5666397ac32021b21e0accee")?;
     let master_hd_key = HDKey::new_master(master_seed, HDNetworkType::TestNet)?;
-    let mut ethereum_wallet = EthereumWallet::builder()
+    let ethereum_wallet = EthereumWallet::builder()
         .master_hd_key(master_hd_key)
         .build()?;
     
@@ -57,7 +57,7 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     println!("tx: {:?}", &tx);
 
     let send_amount = EthereumAmount::from_wei(10_000.into());
-    let tx_hash = ethereum_wallet
+    let _tx_hash = ethereum_wallet
         .transfer(send_amount, GOERLI_TEST_ADDRESS)
         .await
         .unwrap();

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -1,66 +1,51 @@
-// EthereumAmount.new_from_eth(u64)
-// use std::str::FromStr;
+use walletd_ethereum::prelude::*;
+use walletd_hd_key::prelude::*;
+use ethers::prelude::*;
 
-// use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder as oldMnemonicBuilder};
-// // use web3::types::U256;
 
-// use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
-// use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
-// use walletd_hd_key::HDNetworkType;
-
-// use ethers::signers::{LocalWallet, Signer};
-// use ethers::middleware::{gas_oracle::GasNow, MiddlewareBuilder};
-
-// use ethers::{
-//     core::{types::TransactionRequest, utils::Anvil},
-//     providers::{Http, Middleware, Provider},
-// };
-// //use eyre::Result;
-// use std::convert::TryFrom;
-
-// use ethers::{
-//     core::rand,
-// };
-
-use ethers::{
-    core::{types::TransactionRequest},
-    middleware::SignerMiddleware,
-    providers::{Middleware, Provider},
-    signers::{Signer},
-    signers::{coins_bip39::English, MnemonicBuilder},
-};
-
-const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
+//const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
-async fn main() {
-   
-    let phrase = "mandate rude write gather vivid inform leg swift usual early bamboo element"; 
-    let index = 0u32; // The wallet number's index. Indexes in Ethereum start at 0.
+async fn main() -> Result<(), walletd_ethereum::Error> {
+    let master_seed = Seed::from_str("a2fd9c0522d84d52ee4c8533dc02d4b69b4df9b6255e1af20c9f1d4d691689f2a38637eb1ec778972bf845c32d5ae83c7536999b5666397ac32021b21e0accee")?;
+    let master_hd_key = HDKey::new_master(master_seed, HDNetworkType::TestNet)?;
+    let mut ethereum_wallet = EthereumWallet::builder()
+        .master_hd_key(master_hd_key)
+        .build()?;
+    
+    let public_address = ethereum_wallet.public_address();
+    
+    println!("ethereum wallet public address: {}", public_address);
+    
+    assert!(ethereum_wallet.private_key().is_ok());
+    assert!(ethereum_wallet.public_key().is_ok());
+    
+    let derived_hd_key = ethereum_wallet.derived_hd_key()?;
+    let private_key =
+            EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
+    let address_derivation_path = &derived_hd_key.derivation_path.clone();
+    
+    // EthereumWallet stores the private key as a 32 byte array
+    let secret_bytes = private_key.to_bytes();
 
-    // Initialise a provider from a URL
-    // TODO: this should be handled by our EthClient instead of directly calling ethers
+    // Instantiate a provider (connecttion) pointing to the endpoint we want to use
     let provider = Provider::try_from(PROVIDER_URL).unwrap();
 
-    // Initialise a wallet using the Mnemonic Builder (We need to switch this to our facade at some stage)
-    let wallet_nonlocal = MnemonicBuilder::<English>::default()
-        .phrase(phrase)
-        .index(index)
-        .unwrap()
-        .build()
-        .unwrap();
+    // Instantiate a ethers local wallet from the wallet's secret bytes
+    let wfbres = Wallet::from_bytes(&secret_bytes);
 
-    println!("wallet_nonlocal: {:?}", &wallet_nonlocal);
-    println!("provider: {:?}", &provider);
-
+    let wfb = wfbres.unwrap();
     // 5 = goerli chain id 
-    let client = SignerMiddleware::new(provider, wallet_nonlocal.with_chain_id(5u64));
-    println!("client: {:?}", &client);
 
+    // Link our wallet instance to our provider for signing our transactions
+    let client = SignerMiddleware::new(provider, wfb.with_chain_id(5u64));    
+
+    // Create a transaction request to send 10000 wei to the Goerli address
     let tx = TransactionRequest::new()
         .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
         .gas(21000)
-        .value(10000);
+        .value(10000)
+        .chain_id(5u64);
 
     println!("tx: {:?}", &tx);
 
@@ -68,6 +53,36 @@ async fn main() {
 
     let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
     let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
-    
+
     println!("tx: {:?}", &tx);
+
+
+
+
+    assert_eq!(
+        address_derivation_path.to_string(),
+        "m/44'/60'/0'/0/0".to_string()
+    );
+
+    // let lw: LocalWallet = secret_key.parse::<LocalWallet>()?;
+
+    let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+    let eth_client = EthClient::new(ethclient_url)?;
+    let tx_hash = "0xe4216d69bf935587b82243e68189de7ade0aa5b6f70dd0de8636b8d643431c0b";
+    let tx = eth_client.transaction_data_from_hash(tx_hash).await?;
+    let block_number = eth_client.current_block_number().await;
+    let gas_price = eth_client.gas_price().await;
+
+    println!("Block number: {:#?}", block_number);
+    println!("Gas price: {:#?}", gas_price);
+    println!("transaction data: {:?}", tx);
+    ethereum_wallet.set_blockchain_client(eth_client);
+    let balance = ethereum_wallet.balance().await?;
+    println!(
+        "ethereum wallet balance: {} ETH, ({} wei)",
+        balance.eth(),
+        balance.wei()
+    );
+
+    Ok(())
 }

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -11,19 +11,19 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     let ethereum_wallet = EthereumWallet::builder()
         .master_hd_key(master_hd_key)
         .build()?;
-    
+
     let public_address = ethereum_wallet.public_address();
-    
+
     println!("ethereum wallet public address: {}", public_address);
-    
+
     assert!(ethereum_wallet.private_key().is_ok());
     assert!(ethereum_wallet.public_key().is_ok());
-    
+
     let derived_hd_key = ethereum_wallet.derived_hd_key()?;
     let private_key =
-            EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
+        EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
     let address_derivation_path = &derived_hd_key.derivation_path.clone();
-    
+
     // EthereumWallet stores the private key as a 32 byte array
     let secret_bytes = private_key.to_bytes();
 
@@ -34,10 +34,10 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     let wfbres = Wallet::from_bytes(&secret_bytes);
 
     let wfb = wfbres.unwrap();
-    // 5 = goerli chain id 
+    // 5 = goerli chain id
 
     // Link our wallet instance to our provider for signing our transactions
-    let client = SignerMiddleware::new(provider, wfb.with_chain_id(5u64));    
+    let client = SignerMiddleware::new(provider, wfb.with_chain_id(5u64));
 
     // Create a transaction request to send 10000 wei to the Goerli address
     let tx = TransactionRequest::new()
@@ -50,10 +50,16 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
 
     let pending_tx = client.send_transaction(tx, None).await.unwrap();
 
-    let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
-    let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
+    let receipt = pending_tx
+        .await
+        .unwrap()
+        .ok_or_else(|| println!("tx dropped from mempool"))
+        .unwrap();
+    let tx = client
+        .get_transaction(receipt.transaction_hash)
+        .await
+        .unwrap();
 
-    
     println!("tx: {:?}", &tx);
 
     let send_amount = EthereumAmount::from_wei(10_000.into());

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -1,61 +1,122 @@
 // EthereumAmount.new_from_eth(u64)
 // use std::str::FromStr;
 
-use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder};
+use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder as oldMnemonicBuilder};
 // use web3::types::U256;
 
 use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
 use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
 use walletd_hd_key::HDNetworkType;
 
+// use ethers::signers::{LocalWallet, Signer};
+// use ethers::middleware::{gas_oracle::GasNow, MiddlewareBuilder};
+
+// use ethers::{
+//     core::{types::TransactionRequest, utils::Anvil},
+//     providers::{Http, Middleware, Provider},
+// };
+// //use eyre::Result;
+// use std::convert::TryFrom;
+
+// use ethers::{
+//     core::rand,
+// };
+
 use ethers::{
     core::{types::TransactionRequest, utils::Anvil},
+    middleware::SignerMiddleware,
     providers::{Http, Middleware, Provider},
+    signers::{LocalWallet, Signer},
+    signers::{coins_bip39::English, MnemonicBuilder},
 };
-//use eyre::Result;
-use std::convert::TryFrom;
 
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
+const PROV_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 #[tokio::main]
 async fn main() {
     // main_wip()?;
 
-    let mnemonic_phrase: &str =
-        "mandate rude write gather vivid inform leg swift usual early bamboo element";
-    let restored_mnemonic = Bip39Mnemonic::builder()
-        .mnemonic_phrase(mnemonic_phrase)
-        .detect_language()
+    // let provider = Provider::<Http>::connect(PROV_URL).await.unwrap();
+    
+    let phrase = "mandate rude write gather vivid inform leg swift usual early bamboo element";
+    let index = 0u32;
+
+    let provider = Provider::try_from(PROV_URL).unwrap();
+
+    let wallet_nonlocal = MnemonicBuilder::<English>::default()
+        .phrase(phrase)
+        .index(index)
+        .unwrap()
         .build()
         .unwrap();
 
-    let seed = restored_mnemonic.to_seed();
+    println!("provider: {:?}", &provider);
 
-    println!("seed as bytes: {:?}", seed.as_bytes());
+    // 5 = goerli chain id
+    let client = SignerMiddleware::new(provider, wallet_nonlocal);
 
-    let blockchain_client =
-        EthClient::new("https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161").unwrap();
+    let tx = TransactionRequest::new()
+        .to("vitalik.eth")
+        .value(10000);
+    
+    let pending_tx = client.send_transaction(tx, None).await.unwrap();
 
-    println!("blockchain_client: {:?}", &blockchain_client);
+    let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
+    let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
+    
+    println!("tx: {:?}", &tx);
 
-    let mut wallet = EthereumWallet::builder()
-        .mnemonic_seed(seed)
-        .network_type(HDNetworkType::TestNet)
-        .build()
-        .unwrap();
-    wallet.set_blockchain_client(blockchain_client);
-    // This example now assumes that the wallet has been funded with some testnet ETH
-    println!("wallet: {:#?}", &wallet);
+    //let wallet: LocalWallet = "380eb0f3d505f087e438eca80bc4df9a7faa24f868e69fc0440261a0fc0567dc".parse();
 
-    println!("balance: {:?}", &wallet.balance().await.unwrap());
+    //let mut client = SignerMiddleware::new(provider, wallet);
 
-    let sa = ethers::types::U256::from(10000);
-    let send_amount = EthereumAmount::from_wei(sa);
-    println!("send_amount: {:?}", &send_amount);
 
-    let tx_hash = wallet
-        .transfer(&send_amount, GOERLI_TEST_ADDRESS)
-        .await
-        .unwrap();
+    // Access mnemonic phrase with password
+    // Child key at derivation path: m/44'/60'/0'/0/{index}
+    // let wallet: LocalWallet = MnemonicBuilder::<English>::default()
+    //     .phrase(phrase)
+    //     .index(index)?
+    //     // Use this if your mnemonic is encrypted
+    //     .build()?;
 
-    println!("tx_hash: 0x{}", &tx_hash);
+    // let mnemonic_phrase: &str =
+    //     "mandate rude write gather vivid inform leg swift usual early bamboo element";
+    // let restored_mnemonic = Bip39Mnemonic::builder()
+    //     .mnemonic_phrase(mnemonic_phrase)
+    //     .detect_language()
+    //     .build()
+    //     .unwrap();
+
+    // let seed = restored_mnemonic.to_seed();
+
+    // println!("seed as bytes: {:?}", seed.as_bytes());
+
+    // let blockchain_client =
+    //     EthClient::new("https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161").unwrap();
+
+    // println!("blockchain_client: {:?}", &blockchain_client);
+
+    // let mut wallet = EthereumWallet::builder()
+    //     .mnemonic_seed(seed)
+    //     .network_type(HDNetworkType::TestNet)
+    //     .build()
+    //     .unwrap();
+    // wallet.set_blockchain_client(blockchain_client);
+    // // This example now assumes that the wallet has been funded with some testnet ETH
+    // println!("wallet: {:#?}", &wallet);
+
+    // println!("balance: {:?}", &wallet.balance().await.unwrap());
+
+    // let sa = ethers::types::U256::from(10000);
+    // let send_amount = EthereumAmount::from_wei(sa);
+
+    // println!("send_amount: {:?}", &send_amount);
+
+
+    // let tx_hash = wallet
+    //     .transfer(&send_amount, GOERLI_TEST_ADDRESS)
+    //     .await
+    //     .unwrap();
+
+    // println!("tx_hash: 0x{}", &tx_hash);
 }

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -1,14 +1,8 @@
+use ethers::prelude::*;
 use walletd_ethereum::prelude::*;
 use walletd_hd_key::prelude::*;
-use ethers::prelude::*;
 
-
-//const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 const PROVIDER_URL: &str = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-use walletd_coin_core::BlockchainConnector;
-use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
-use walletd_hd_key::HDNetworkType;
-
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 #[tokio::main]
 async fn main() -> Result<(), walletd_ethereum::Error> {
@@ -59,8 +53,11 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
     let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
 
+    
     println!("tx: {:?}", &tx);
-    let tx_hash = wallet
+
+    let send_amount = EthereumAmount::from_wei(10_000.into());
+    let tx_hash = ethereum_wallet
         .transfer(send_amount, GOERLI_TEST_ADDRESS)
         .await
         .unwrap();
@@ -69,8 +66,6 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
         address_derivation_path.to_string(),
         "m/44'/60'/0'/0/0".to_string()
     );
-
-    // let lw: LocalWallet = secret_key.parse::<LocalWallet>()?;
 
     Ok(())
 }

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -2,11 +2,18 @@
 // use std::str::FromStr;
 
 use walletd_bip39::{Bip39Mnemonic, Mnemonic, MnemonicBuilder};
-use web3::types::U256;
+// use web3::types::U256;
 
 use walletd_coin_core::{BlockchainConnector, CryptoWallet, CryptoWalletBuilder};
 use walletd_ethereum::{EthClient, EthereumAmount, EthereumWallet};
 use walletd_hd_key::HDNetworkType;
+
+use ethers::{
+    core::{types::TransactionRequest, utils::Anvil},
+    providers::{Http, Middleware, Provider},
+};
+//use eyre::Result;
+use std::convert::TryFrom;
 
 const GOERLI_TEST_ADDRESS: &str = "0xFf7FD50BF684eb853787179cc9c784b55Ac68699";
 #[tokio::main]
@@ -14,7 +21,7 @@ async fn main() {
     // main_wip()?;
 
     let mnemonic_phrase: &str =
-        "joy tail arena mix other envelope diary achieve short nest true vocal";
+        "mandate rude write gather vivid inform leg swift usual early bamboo element";
     let restored_mnemonic = Bip39Mnemonic::builder()
         .mnemonic_phrase(mnemonic_phrase)
         .detect_language()
@@ -41,7 +48,7 @@ async fn main() {
 
     println!("balance: {:?}", &wallet.balance().await.unwrap());
 
-    let sa = U256::from(10000);
+    let sa = ethers::types::U256::from(10000);
     let send_amount = EthereumAmount::from_wei(sa);
     println!("send_amount: {:?}", &send_amount);
 

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -50,16 +50,20 @@ async fn main() {
         .build()
         .unwrap();
 
+    println!("wallet_nonlocal: {:?}", &wallet_nonlocal);
     println!("provider: {:?}", &provider);
 
     // 5 = goerli chain id 
     let client = SignerMiddleware::new(provider, wallet_nonlocal.with_chain_id(5u64));
+    println!("client: {:?}", &client);
 
     let tx = TransactionRequest::new()
         .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
         .gas(21000)
         .value(10000);
-     
+
+    println!("tx: {:?}", &tx);
+
     let pending_tx = client.send_transaction(tx, None).await.unwrap();
 
     let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();

--- a/coins/ethereum/src/error.rs
+++ b/coins/ethereum/src/error.rs
@@ -33,9 +33,9 @@ pub enum Error {
     /// Converted ParseInt error
     #[error("ParseInt error: {0}")]
     ParseInt(#[from] std::num::ParseIntError),
-    /// Convert web3 error
-    #[error("web3 error: {0}")]
-    FromWeb3(#[from] web3::Error),
+    // Convert web3 error
+    // #[error("web3 error: {0}")]
+    // FromWeb3(#[from] web3::Error),
     /// Error related to converting from or to a hex
     #[error("Hex error: {0}")]
     Hex(#[from] hex::FromHexError),
@@ -60,10 +60,10 @@ pub enum Error {
     /// Error due to overflow
     #[error("Overflow error: {0}")]
     Overflow(String),
-    /// Error from web3 contract
-    #[error("Error from web3 contract: {0}")]
-    Web3Contract(#[from] web3::contract::Error),
-    /// Error from web3 ethabi
-    #[error("Error from web3 ethabi: {0}")]
-    Web3Ethabi(#[from] web3::ethabi::Error),
+    // Error from web3 contract
+    // #[error("Error from web3 contract: {0}")]
+    // Web3Contract(#[from] web3::contract::Error),
+    // Error from web3 ethabi
+    // #[error("Error from web3 ethabi: {0}")]
+    // Web3Ethabi(#[from] web3::ethabi::Error),
 }

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -9,7 +9,7 @@ use web3::ethabi::Uint;
 use web3::helpers as w3h;
 use web3::transports::Http;
 use ethers::types::Address;
-use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
+// use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
 use ethers::prelude::*;
 use ethers::providers::{Middleware, Provider};
 use ethers::providers::Http as ethersHttp;

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -40,6 +40,12 @@ impl EthClient {
         self.ethers.clone()
     }
 
+    /// Returns the chain id of the current network the ethers instance is connected to.
+    pub async fn chain_id(&self) -> U256 {
+        let chain_id = self.ethers.get_chainid().await.unwrap();
+        chain_id
+    }
+
     /// Returns the balance of an address as an [EthereumAmount].
     pub async fn balance(&self, address: Address) -> Result<EthereumAmount, Error> {
         let balance = self.ethers().get_balance(address, None).await.unwrap();
@@ -388,7 +394,7 @@ impl BlockchainConnector for EthClient {
         println!("endpoint: {:?}", endpoint);
         // TODO(#71): Change transport to support web sockets
         let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-        let ethers = Provider::<Http>::try_from(ethclient_url).unwrap();
+        let ethers = Provider::try_from(ethclient_url).unwrap();
         // With these latest changes, we can only possibly be using ethers when we leverage EthClient correctly
 
         Ok(Self {

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -393,17 +393,9 @@ impl BlockchainConnector for EthClient {
     fn new(endpoint: &str) -> Result<Self, Error> {
         println!("endpoint: {:?}", endpoint);
         // TODO(#71): Change transport to support web sockets
-        //ethers
-        
-        // change this to endpoint
         let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-        //let ethers = Provider::<ethersHttp::Http>::new(ethclient_url)?;
         let ethers = Provider::<ethersHttp>::try_from(ethclient_url).unwrap();
-        // web3
-        println!("ethers");
-        // let transport = web3::transports::Http::new(endpoint)?;
-        // let web3 = &ethers.clone();
-        // let eth_client = EthClient::new(ethclient_url)?;
+        // With these latest changes, we can only possibly be using ethers when we leverage EthClient correctly
 
         Ok(Self {
             // web3,

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -48,8 +48,8 @@ impl EthClient {
     /// # async fn example() -> Result<(), walletd_ethereum::Error> {
     /// let tx_hash =
     ///     "0xe4216d69bf935587b82243e68189de7ade0aa5b6f70dd0de8636b8d643431c0b";
-    /// let infura_goelri_endpoint_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-    /// let eth_client = EthClient::new(infura_goelri_endpoint_url)?;
+    /// let infura_goerli_endpoint_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+    /// let eth_client = EthClient::new(infura_goerli_endpoint_url)?;
     /// let tx = eth_client.transaction_data_from_hash(tx_hash).await?;
     /// println!("tx data: {:?}", tx);
     /// # Ok(())

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -88,8 +88,7 @@ impl EthClient {
 
     // TODO(#70): Remove this after write-only functionality is finished
     /// Debug transaction for adding smart contract functionality
-    async fn print_txdata_for_block(&self, block: &web3::types::Block<H256>) {
-        todo!()
+    // async fn print_txdata_for_block(&self, block: &web3::types::Block<H256>) {
         // for transaction_hash in &block.transactions {
         //     let tx = match self
         //         .ethers()
@@ -114,11 +113,11 @@ impl EthClient {
         //         tx.gas_price,
         //     );
         // }
-    }
+    // }
 
     ///  Prints out info on a smart contract transaction from a block hash
-    async fn get_smart_contract_tx_vec_from_block_hash(&self, block: &web3::types::Block<H256>) {
-        todo!()
+    // async fn get_smart_contract_tx_vec_from_block_hash(&self, block: &web3::types::Block<H256>) {
+        // todo!()
         // for transaction_hash in &block.transactions {
         //     let tx = match self
         //         .web3
@@ -167,11 +166,11 @@ impl EthClient {
         //         }
         //     }
         // }
-    }
+    // }
 
     /// Filters a block for all ERC-20 compliant transactions
     /// This leverages the standardised ERC20 Application Binary Interface
-    async fn smart_contract_transactions(&self, block: &web3::types::Block<H256>) {
+    // async fn smart_contract_transactions(&self, block: &web3::types::Block<H256>) {
         // for transaction_hash in &block.transactions {
         //     let tx = match self
         //         .ethers()
@@ -225,7 +224,7 @@ impl EthClient {
         //     // };
         // }
         // // info!("{:#?}", smart_contract_addr);
-    }
+    // }
 
     /// Given a specified address, retrieves the [Ethereum balance][EthereumAmount] of that
     /// [address][Address].
@@ -299,7 +298,7 @@ impl EthClient {
     }
 
     /// Get the latest block number for the current network chain.
-    pub async fn current_block_number(&self) -> web3::Result<u64> {
+    pub async fn current_block_number(&self) -> Result<u64, Error> {
         let block_number: ethers::types::U64 = self.ethers.get_block_number().await.unwrap();
         Ok(block_number.as_u64())
     }
@@ -333,7 +332,7 @@ impl EthClient {
     // no transaction data returned by Web3's block struct. This appears to be a bug
     // in Web3. This may be fixed by ethers.rs in which case we don't need block_data_from_numeric_string
     #[allow(non_snake_case)]
-    async fn block_data_from_U64(&self, block_id: U64) -> web3::Result<Block<H256>> {
+    async fn block_data_from_U64(&self, block_id: U64) -> Result<Block<H256>, Error> {
         let blockid = BlockNumber::Number(block_id);
         let block_data = &self
             .ethers()
@@ -350,7 +349,7 @@ impl EthClient {
     async fn block_data_from_numeric_string(
         &self,
         block_id: &str,
-    ) -> web3::Result<ethers::types::Block<H256>> {
+    ) -> Result<ethers::types::Block<H256>, Error> {
         // we're using a string because U64 is a web3 type
         let block_number = block_id.parse::<U64>().unwrap();
         let blockid = BlockNumber::Number(block_number);
@@ -372,7 +371,7 @@ impl BlockchainConnector for EthClient {
     /// Returns an [error][Error] if the endpoint is invalid or the transport fails to connect.
     fn new(endpoint: &str) -> Result<Self, Error> {
         println!("endpoint: {:?}", endpoint);
-        // TODO(#71): Change transport to support web sockets
+        // TODO(#71): Update transport to support web sockets
         let ethers = Provider::try_from(endpoint).unwrap();
         Ok(Self {
             ethers,
@@ -384,19 +383,3 @@ impl BlockchainConnector for EthClient {
         &self.endpoint
     }
 }
-
-// #[cfg(test)]
-// mod tests {
-//     use super::*;
-    
-
-//     fn test_zeroize() -> Result<(), Error> {
-//         let phrase: &str = "outer ride neither foil glue number place usage ball shed dry point";
-//         let mut mnemonic = Bip39Mnemonic::builder().mnemonic_phrase(phrase).build()?;
-//         mnemonic.zeroize();
-//         assert_eq!(mnemonic.seed.as_bytes(), &[]);
-//         assert_eq!(mnemonic.phrase, "");
-//         Ok(())
-//     }
-
-// }

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -10,6 +10,7 @@ use web3::helpers as w3h;
 use web3::transports::Http;
 use web3::types::Address;
 use web3::types::{BlockId, BlockNumber, TransactionId, H160, H256, U64};
+use ethers::prelude::*;
 
 #[allow(dead_code)]
 pub enum TransportType {

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -260,8 +260,9 @@ impl EthClient {
     async fn balance_of_smart_contract(
         &self,
         smart_contract: &web3::contract::Contract<Http>,
-        address: Address,
+        address: ethers::types::Address,
     ) -> Result<String, Error> {
+        todo!();
         let balance = smart_contract
             .query("balanceOf", address, None, Options::default(), None)
             .await?;
@@ -352,12 +353,11 @@ impl EthClient {
     // no transaction data returned by Web3's block struct. This appears to be a bug
     // in Web3
     #[allow(non_snake_case)]
-    async fn block_data_from_U64(&self, block_id: U64) -> web3::Result<web3::types::Block<H256>> {
+    async fn block_data_from_U64(&self, block_id: U64) -> web3::Result<Block<H256>> {
         let blockid = BlockNumber::Number(block_id);
         let block_data = &self
-            .web3
-            .eth()
-            .block(BlockId::Number(blockid))
+            .ethers()
+            .get_block(BlockId::Number(blockid))
             .await
             .unwrap()
             .unwrap();

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -1,18 +1,18 @@
 use crate::Error;
 use crate::EthereumAmount;
 use async_trait::async_trait;
-use log::info;
+
 use std::str::FromStr;
 use walletd_coin_core::BlockchainConnector;
-use web3::contract::{Contract, Options};
-use web3::ethabi::Uint;
-use web3::helpers as w3h;
+
+
+
 use ethers::types::Address;
 // use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
 use ethers::prelude::*;
 use ethers::providers::{Middleware, Provider};
 use ethers::providers::Http;
-use ethers::types::{BlockId, Block, BlockNumber, H160, H256, U64};
+use ethers::types::{BlockId, Block, BlockNumber, H256, U64};
 use std::convert::TryFrom;
 
 
@@ -42,8 +42,8 @@ impl EthClient {
 
     /// Returns the chain id of the current network the ethers instance is connected to.
     pub async fn chain_id(&self) -> U256 {
-        let chain_id = self.ethers.get_chainid().await.unwrap();
-        chain_id
+        
+        self.ethers.get_chainid().await.unwrap()
     }
 
     /// Returns the balance of an address as an [EthereumAmount].

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -28,7 +28,7 @@ pub enum TransportType {
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct EthClient {
-    web3: web3::Web3<web3::transports::Http>,
+    //web3: web3::Web3<web3::transports::Http>,
     ethers: Provider<ethersHttp>,
     endpoint: String,
 }
@@ -36,8 +36,8 @@ pub struct EthClient {
 #[allow(unused)]
 impl EthClient {
     /// Returns the web3 instance.
-    pub fn web3(&self) -> web3::Web3<web3::transports::Http> {
-        self.web3.clone()
+    pub fn web3(&self) -> Provider<ethersHttp> {
+        self.ethers.clone()
     }
 
     pub fn ethers(&self) -> Provider<ethersHttp> {
@@ -50,7 +50,7 @@ impl EthClient {
     // }
 
     /// Returns the balance of an address as an [EthereumAmount].
-    pub async fn balance(&self, address: H160) -> Result<EthereumAmount, Error> {
+    pub async fn balance(&self, address: Address) -> Result<EthereumAmount, Error> {
         let balance = self.ethers().get_balance(address, None).await.unwrap();
         Ok(EthereumAmount { wei: balance })
     }
@@ -392,6 +392,7 @@ impl BlockchainConnector for EthClient {
     /// Create a new instance of [EthClient] based on a given endpoint url.
     /// Returns an [error][Error] if the endpoint is invalid or the transport fails to connect.
     fn new(endpoint: &str) -> Result<Self, Error> {
+        println!("endpoint: {:?}", endpoint);
         // TODO(#71): Change transport to support web sockets
         //ethers
         
@@ -400,12 +401,13 @@ impl BlockchainConnector for EthClient {
         //let ethers = Provider::<ethersHttp::Http>::new(ethclient_url)?;
         let ethers = Provider::<ethersHttp>::try_from(ethclient_url).unwrap();
         // web3
-        
-        let transport = web3::transports::Http::new(endpoint)?;
-        let web3 = web3::Web3::new(transport);
-        let eth_client = EthClient::new(ethclient_url)?;
+        println!("ethers");
+        // let transport = web3::transports::Http::new(endpoint)?;
+        // let web3 = &ethers.clone();
+        // let eth_client = EthClient::new(ethclient_url)?;
+
         Ok(Self {
-            web3,
+            // web3,
             ethers,
             endpoint: endpoint.to_string(), // web3 uses an &str for endpoint
         })

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -11,15 +11,8 @@ use std::str::FromStr;
 use std::convert::TryFrom;
 use walletd_coin_core::BlockchainConnector;
 
-#[allow(dead_code)]
-pub enum TransportType {
-    Http,
-    WebSockets,
-}
-
 /// A blockchain connector for Ethereum which contains a [`instance of ethers `](https://github.com/gakonst/ethers-rs) using a HTTP transport.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct EthClient {
     ethers: Provider<Http>,
     endpoint: String,

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -63,7 +63,7 @@ impl EthClient {
         let transaction_hash = H256::from_str(tx_hash).unwrap();
         match self.ethers().get_transaction(transaction_hash).await {
             Ok(tx) => {
-                let transaction_data = tx.unwrap(); 
+                let transaction_data = tx.unwrap();
                 if transaction_data.block_hash.is_none() {
                     Err(Error::TxResponse(format!(
                         "Transaction with tx_hash {} not found",
@@ -75,8 +75,8 @@ impl EthClient {
             }
             Err(error) => {
                 println!("Did not get");
-                Err(Error::TxResponse(error.to_string())
-            )},
+                Err(Error::TxResponse(error.to_string()))
+            }
         }
     }
 

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -7,12 +7,11 @@ use walletd_coin_core::BlockchainConnector;
 use web3::contract::{Contract, Options};
 use web3::ethabi::Uint;
 use web3::helpers as w3h;
-use web3::transports::Http;
 use ethers::types::Address;
 // use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
 use ethers::prelude::*;
 use ethers::providers::{Middleware, Provider};
-use ethers::providers::Http as ethersHttp;
+use ethers::providers::Http;
 use ethers::types::{BlockId, Block, BlockNumber, H160, H256, U64};
 use std::convert::TryFrom;
 
@@ -29,25 +28,17 @@ pub enum TransportType {
 #[allow(dead_code)]
 pub struct EthClient {
     //web3: web3::Web3<web3::transports::Http>,
-    ethers: Provider<ethersHttp>,
+    ethers: Provider<Http>,
     endpoint: String,
 }
 
 #[allow(unused)]
 impl EthClient {
-    /// Returns the web3 instance.
-    pub fn web3(&self) -> Provider<ethersHttp> {
+
+    /// Returns the ethers Provider instance.
+    pub fn ethers(&self) -> Provider<Http> {
         self.ethers.clone()
     }
-
-    pub fn ethers(&self) -> Provider<ethersHttp> {
-        self.ethers.clone()
-    }
-
-    /// Returns the eth instance from the web3 instance.
-    // pub fn eth(&self) -> web3::api::Eth<web3::transports::Http> {
-    //     self.ethers.eth()
-    // }
 
     /// Returns the balance of an address as an [EthereumAmount].
     pub async fn balance(&self, address: Address) -> Result<EthereumAmount, Error> {
@@ -271,39 +262,42 @@ impl EthClient {
 
     /// Given a specified contract instance, determine the total supply of
     /// tokens
-    async fn total_supply(
-        &self,
-        smart_contract: &web3::contract::Contract<Http>,
-    ) -> Result<Uint, ()> {
-        let total_supply = smart_contract
-            .query("totalSupply", (), None, Options::default(), None)
-            .await;
+    // TODO: Migrate 
+    // async fn total_supply(
+    //     &self,
+    //     smart_contract: &web3::contract::Contract<Http>,
+    // ) -> Result<Uint, ()> {
+    //     let total_supply = smart_contract
+    //         .query("totalSupply", (), None, Options::default(), None)
+    //         .await;
 
-        Ok(total_supply.unwrap())
-    }
+    //     Ok(total_supply.unwrap())
+    // }
 
     /// Given a specified contract instance, retrieve the name of the token
-    async fn get_token_name(
-        &self,
-        contract: &web3::contract::Contract<Http>,
-    ) -> Result<String, ()> {
-        let token_name = contract
-            .query("name", (), None, Options::default(), None)
-            .await;
-        Ok(token_name.unwrap())
-    }
+    // TODO: Migrate
+    // async fn get_token_name(
+    //     &self,
+    //     contract: &web3::contract::Contract<Http>,
+    // ) -> Result<String, ()> {
+    //     let token_name = contract
+    //         .query("name", (), None, Options::default(), None)
+    //         .await;
+    //     Ok(token_name.unwrap())
+    // }
 
     /// Initialises an instance of an ERC20-compliant smart contract we can
     /// subsequently interact with
     // erc20_abi.json describes standard ERC20 functions
-    fn initialise_contract(&self, addr: H160) -> Result<web3::contract::Contract<Http>, Error> {
-        todo!()
-        // Ok(Contract::from_json(
-        //     self.web3.eth(),
-        //     addr,
-        //     include_bytes!("./abi/erc20_abi.json"),
-        // )?)
-    }
+    // TODO: migrate still
+    // fn initialise_contract(&self, addr: H160) -> Result<web3::contract::Contract<Http>, Error> {
+    //     todo!()
+    //     // Ok(Contract::from_json(
+    //     //     self.web3.eth(),
+    //     //     addr,
+    //     //     include_bytes!("./abi/erc20_abi.json"),
+    //     // )?)
+    // }
 
     /// Get the current price of gas as an [EthereumAmount].
     pub async fn gas_price(&self) -> Result<EthereumAmount, Error> {
@@ -394,7 +388,7 @@ impl BlockchainConnector for EthClient {
         println!("endpoint: {:?}", endpoint);
         // TODO(#71): Change transport to support web sockets
         let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-        let ethers = Provider::<ethersHttp>::try_from(ethclient_url).unwrap();
+        let ethers = Provider::<Http>::try_from(ethclient_url).unwrap();
         // With these latest changes, we can only possibly be using ethers when we leverage EthClient correctly
 
         Ok(Self {

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -1,21 +1,15 @@
 use crate::Error;
 use crate::EthereumAmount;
+
 use async_trait::async_trait;
-
-use std::str::FromStr;
-use walletd_coin_core::BlockchainConnector;
-
-
-
 use ethers::types::Address;
-// use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
 use ethers::prelude::*;
-use ethers::providers::{Middleware, Provider};
-use ethers::providers::Http;
-use ethers::types::{BlockId, Block, BlockNumber, H256, U64};
+// use ethers::providers::{Middleware, Provider};
+// use ethers::providers::Http;
+// use ethers::types::{BlockId, Block, BlockNumber, H256, U64};
+use std::str::FromStr;
 use std::convert::TryFrom;
-
-
+use walletd_coin_core::BlockchainConnector;
 
 #[allow(dead_code)]
 pub enum TransportType {
@@ -23,11 +17,10 @@ pub enum TransportType {
     WebSockets,
 }
 
-/// A blockchain connector for Ethereum which contains a [`web3 instance`](https://github.com/tomusdrw/rust-web3) using a HTTP transport.
+/// A blockchain connector for Ethereum which contains a [`instance of ethers `](https://github.com/gakonst/ethers-rs) using a HTTP transport.
 #[derive(Clone, Debug)]
 #[allow(dead_code)]
 pub struct EthClient {
-    //web3: web3::Web3<web3::transports::Http>,
     ethers: Provider<Http>,
     endpoint: String,
 }
@@ -310,16 +303,10 @@ impl EthClient {
         // getting gas price
         let gas_price = self.ethers.get_gas_price().await.unwrap();
         Ok(EthereumAmount { wei: gas_price })
-
-
-        // let gas_price = self.web3.eth().gas_price().await?;
-        // Ok(EthereumAmount { wei: gas_price })
     }
 
     /// Get the latest block number for the current network chain.
     pub async fn current_block_number(&self) -> web3::Result<u64> {
-        //let block_number = &self.ethers.block_number().await?;
-        // Ok(block_number.as_u64())
         let block_number: ethers::types::U64 = self.ethers.get_block_number().await.unwrap();
         Ok(block_number.as_u64())
     }
@@ -351,7 +338,7 @@ impl EthClient {
     ///
     // TODO:(#73) - when using U64,
     // no transaction data returned by Web3's block struct. This appears to be a bug
-    // in Web3
+    // in Web3. This may be fixed by ethers.rs in which case we don't need block_data_from_numeric_string
     #[allow(non_snake_case)]
     async fn block_data_from_U64(&self, block_id: U64) -> web3::Result<Block<H256>> {
         let blockid = BlockNumber::Number(block_id);
@@ -394,12 +381,9 @@ impl BlockchainConnector for EthClient {
         println!("endpoint: {:?}", endpoint);
         // TODO(#71): Change transport to support web sockets
         let ethers = Provider::try_from(endpoint).unwrap();
-        // With these latest changes, we can only possibly be using ethers when we leverage EthClient correctly
-        println!("ethers: {:?}", &ethers);
         Ok(Self {
-            // web3,
             ethers,
-            endpoint: endpoint.to_string(), // web3 uses an &str for endpoint
+            endpoint: endpoint.to_string(),
         })
     }
     /// Returns the url of the endpoint associated with the [EthClient].

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -393,10 +393,9 @@ impl BlockchainConnector for EthClient {
     fn new(endpoint: &str) -> Result<Self, Error> {
         println!("endpoint: {:?}", endpoint);
         // TODO(#71): Change transport to support web sockets
-        let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-        let ethers = Provider::try_from(ethclient_url).unwrap();
+        let ethers = Provider::try_from(endpoint).unwrap();
         // With these latest changes, we can only possibly be using ethers when we leverage EthClient correctly
-
+        println!("ethers: {:?}", &ethers);
         Ok(Self {
             // web3,
             ethers,

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -77,31 +77,30 @@ impl EthClient {
     pub async fn transaction_data_from_hash(
         &self,
         tx_hash: &str,
-    ) -> Result<web3::types::Transaction, Error> {
-        todo!()
-        // let transaction_hash: H256 =
-        //     H256::from_str(tx_hash).map_err(|e| Error::FromStr(e.to_string()))?;
+    ) -> Result<ethers::types::Transaction, Error> {
+        let transaction_hash: H256 =
+            H256::from_str(tx_hash).map_err(|e| Error::FromStr(e.to_string()))?;
 
-        // let transaction_hash: H256 =
-        //     H256::from_str(tx_hash).map_err(|e| Error::FromStr(e.to_string()))?;
-        // match self
-        //     .web3
-        //     .eth()
-        //     .transaction(TransactionId::Hash(transaction_hash))
-        //     .await
-        // {
-        //     Ok(tx) => {
-        //         if tx.is_none() {
-        //             Err(Error::TxResponse(format!(
-        //                 "Transaction with tx_hash {} not found",
-        //                 tx_hash
-        //             )))
-        //         } else {
-        //             Ok(tx.unwrap())
-        //         }
-        //     }
-        //     Err(error) => Err(Error::TxResponse(error.to_string())),
-        // }
+        let transaction_hash: H256 =
+            H256::from_str(tx_hash).map_err(|e| Error::FromStr(e.to_string()))?;
+
+        match self
+            .ethers
+            .get_transaction(transaction_hash)
+            .await
+        {
+            Ok(tx) => {
+                if tx.is_none() {
+                    Err(Error::TxResponse(format!(
+                        "Transaction with tx_hash {} not found",
+                        tx_hash
+                    )))
+                } else {
+                    Ok(tx.unwrap())
+                }
+            }
+            Err(error) => Err(Error::TxResponse(error.to_string())),
+        }
     }
 
     // TODO(#70): Remove this after write-only functionality is finished

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -408,3 +408,19 @@ impl BlockchainConnector for EthClient {
         &self.endpoint
     }
 }
+
+// #[cfg(test)]
+// mod tests {
+//     use super::*;
+    
+
+//     fn test_zeroize() -> Result<(), Error> {
+//         let phrase: &str = "outer ride neither foil glue number place usage ball shed dry point";
+//         let mut mnemonic = Bip39Mnemonic::builder().mnemonic_phrase(phrase).build()?;
+//         mnemonic.zeroize();
+//         assert_eq!(mnemonic.seed.as_bytes(), &[]);
+//         assert_eq!(mnemonic.phrase, "");
+//         Ok(())
+//     }
+
+// }

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -45,9 +45,9 @@ impl EthClient {
     }
 
     /// Returns the eth instance from the web3 instance.
-    pub fn eth(&self) -> web3::api::Eth<web3::transports::Http> {
-        self.web3.eth()
-    }
+    // pub fn eth(&self) -> web3::api::Eth<web3::transports::Http> {
+    //     self.ethers.eth()
+    // }
 
     /// Returns the balance of an address as an [EthereumAmount].
     pub async fn balance(&self, address: H160) -> Result<EthereumAmount, Error> {
@@ -190,59 +190,59 @@ impl EthClient {
     /// Filters a block for all ERC-20 compliant transactions
     /// This leverages the standardised ERC20 Application Binary Interface
     async fn smart_contract_transactions(&self, block: &web3::types::Block<H256>) {
-        for transaction_hash in &block.transactions {
-            let tx = match self
-                .ethers()
-                .get_transaction(TransactionId::Hash(*transaction_hash))
-                .await
-            {
-                Ok(tx) => Ok(tx),
-                Err(error) => Err(Error::TxResponse(error.to_string())),
-                Ok(None) => Err(Error::TxResponse(format!(
-                    "Transaction hash {} not found",
-                    transaction_hash
-                ))),
-            };
-            info!("transaction data {:#?}", tx);
-            // TODO(AS): refactor this to uncomment this section or handle the way needeed for first public release version
-            // let smart_contract_addr = match tx.unwrap().to {
-            //     Some(addr) => match &self.web3.eth().code(addr,
-            // None).await {         Ok(code) => {
-            //             if code == &web3::types::Bytes::from([]) {
-            //                 // "Empty code, skipping
-            //                 continue;
-            //             } else {
-            //                 // "Non empty code, this address has bytecode
-            // we have retrieved                 // Attempt
-            // to initialise an instance of an ERC20 contract at this
-            //                 // address
-            //                 let smart_contract =
-            // self.initialise_contract(addr).unwrap();
-            //                 let token_name: String =
-            //
-            // self.get_token_name(&smart_contract).await.unwrap();
+        // for transaction_hash in &block.transactions {
+        //     let tx = match self
+        //         .ethers()
+        //         .get_transaction(ethers::types::Transaction)
+        //         .await
+        //     {
+        //         Ok(tx) => Ok(tx),
+        //         Err(error) => Err(Error::TxResponse(error.to_string())),
+        //         Ok(None) => Err(Error::TxResponse(format!(
+        //             "Transaction hash {} not found",
+        //             transaction_hash
+        //         ))),
+        //     };
+        //     info!("transaction data {:#?}", tx);
+        //     // TODO(AS): refactor this to uncomment this section or handle the way needeed for first public release version
+        //     // let smart_contract_addr = match tx.unwrap().to {
+        //     //     Some(addr) => match &self.web3.eth().code(addr,
+        //     // None).await {         Ok(code) => {
+        //     //             if code == &web3::types::Bytes::from([]) {
+        //     //                 // "Empty code, skipping
+        //     //                 continue;
+        //     //             } else {
+        //     //                 // "Non empty code, this address has bytecode
+        //     // we have retrieved                 // Attempt
+        //     // to initialise an instance of an ERC20 contract at this
+        //     //                 // address
+        //     //                 let smart_contract =
+        //     // self.initialise_contract(addr).unwrap();
+        //     //                 let token_name: String =
+        //     //
+        //     // self.get_token_name(&smart_contract).await.unwrap();
 
-            //                 // Attempt to get and print the total supply
-            // of an ERC20-compliant                 //
-            // contract                 let total_supply:
-            // Uint =
-            // self.total_supply(&smart_contract).await.unwrap();
+        //     //                 // Attempt to get and print the total supply
+        //     // of an ERC20-compliant                 //
+        //     // contract                 let total_supply:
+        //     // Uint =
+        //     // self.total_supply(&smart_contract).await.unwrap();
 
-            //                 info!("token name {:#?}", token_name);
-            //                 info!("token supply {:#?}", total_supply);
-            //             }
-            //         }
-            //         _ => {
-            //             continue;
-            //         }
-            //     },
-            //     _ => {
-            //         // info!("To address is not a valid address,
-            // skipping.");         continue;
-            //     }
-            // };
-        }
-        // info!("{:#?}", smart_contract_addr);
+        //     //                 info!("token name {:#?}", token_name);
+        //     //                 info!("token supply {:#?}", total_supply);
+        //     //             }
+        //     //         }
+        //     //         _ => {
+        //     //             continue;
+        //     //         }
+        //     //     },
+        //     //     _ => {
+        //     //         // info!("To address is not a valid address,
+        //     // skipping.");         continue;
+        //     //     }
+        //     // };
+        // }
+        // // info!("{:#?}", smart_contract_addr);
     }
 
     /// Given a specified address, retrieves the [Ethereum balance][EthereumAmount] of that
@@ -257,16 +257,17 @@ impl EthClient {
 
     /// Given a specified smart contract (ERC20) instance, determine the
     /// token balance for a given address.
+
     async fn balance_of_smart_contract(
         &self,
-        smart_contract: &web3::contract::Contract<Http>,
+        smart_contract: &ethers::contract::Contract<Http>,
         address: ethers::types::Address,
     ) -> Result<String, Error> {
         todo!();
-        let balance = smart_contract
-            .query("balanceOf", address, None, Options::default(), None)
-            .await?;
-        Ok(balance)
+        // let balance = smart_contract
+        //     .query("balanceOf", address, None, Options::default(), None)
+        //     .await?;
+        // Ok(balance)
     }
 
     /// Given a specified contract instance, determine the total supply of

--- a/coins/ethereum/src/ethclient.rs
+++ b/coins/ethereum/src/ethclient.rs
@@ -2,13 +2,13 @@ use crate::Error;
 use crate::EthereumAmount;
 
 use async_trait::async_trait;
-use ethers::types::Address;
 use ethers::prelude::*;
+use ethers::types::Address;
 // use ethers::providers::{Middleware, Provider};
 // use ethers::providers::Http;
 // use ethers::types::{BlockId, Block, BlockNumber, H256, U64};
-use std::str::FromStr;
 use std::convert::TryFrom;
+use std::str::FromStr;
 use walletd_coin_core::BlockchainConnector;
 
 /// A blockchain connector for Ethereum which contains a [`instance of ethers `](https://github.com/gakonst/ethers-rs) using a HTTP transport.
@@ -20,7 +20,6 @@ pub struct EthClient {
 
 #[allow(unused)]
 impl EthClient {
-
     /// Returns the ethers Provider instance.
     pub fn ethers(&self) -> Provider<Http> {
         self.ethers.clone()
@@ -28,7 +27,6 @@ impl EthClient {
 
     /// Returns the chain id of the current network the ethers instance is connected to.
     pub async fn chain_id(&self) -> U256 {
-        
         self.ethers.get_chainid().await.unwrap()
     }
 
@@ -67,11 +65,7 @@ impl EthClient {
         let transaction_hash: H256 =
             H256::from_str(tx_hash).map_err(|e| Error::FromStr(e.to_string()))?;
 
-        match self
-            .ethers
-            .get_transaction(transaction_hash)
-            .await
-        {
+        match self.ethers.get_transaction(transaction_hash).await {
             Ok(tx) => {
                 if tx.is_none() {
                     Err(Error::TxResponse(format!(
@@ -89,141 +83,141 @@ impl EthClient {
     // TODO(#70): Remove this after write-only functionality is finished
     /// Debug transaction for adding smart contract functionality
     // async fn print_txdata_for_block(&self, block: &web3::types::Block<H256>) {
-        // for transaction_hash in &block.transactions {
-        //     let tx = match self
-        //         .ethers()
-        //         .get_transaction(transaction_hash)
-        //         .await
-        //         .unwrap()
-        //     {
-        //         Ok(Some(tx)) => tx,
-        //         _ => {
-        //             continue;
-        //         }
-        //     };
-        //     let from_addr = tx.from.unwrap_or(H160::zero());
-        //     let to_addr = tx.to.unwrap_or(H160::zero());
-        //     info!(
-        //         "[{}] from {}, to {}, value {}, gas {}, gas price {:?}",
-        //         tx.transaction_index.unwrap_or(U64::from(0)),
-        //         w3h::to_string(&from_addr),
-        //         w3h::to_string(&to_addr),
-        //         tx.value,
-        //         tx.gas,
-        //         tx.gas_price,
-        //     );
-        // }
+    // for transaction_hash in &block.transactions {
+    //     let tx = match self
+    //         .ethers()
+    //         .get_transaction(transaction_hash)
+    //         .await
+    //         .unwrap()
+    //     {
+    //         Ok(Some(tx)) => tx,
+    //         _ => {
+    //             continue;
+    //         }
+    //     };
+    //     let from_addr = tx.from.unwrap_or(H160::zero());
+    //     let to_addr = tx.to.unwrap_or(H160::zero());
+    //     info!(
+    //         "[{}] from {}, to {}, value {}, gas {}, gas price {:?}",
+    //         tx.transaction_index.unwrap_or(U64::from(0)),
+    //         w3h::to_string(&from_addr),
+    //         w3h::to_string(&to_addr),
+    //         tx.value,
+    //         tx.gas,
+    //         tx.gas_price,
+    //     );
+    // }
     // }
 
     ///  Prints out info on a smart contract transaction from a block hash
     // async fn get_smart_contract_tx_vec_from_block_hash(&self, block: &web3::types::Block<H256>) {
-        // todo!()
-        // for transaction_hash in &block.transactions {
-        //     let tx = match self
-        //         .web3
-        //         .eth()
-        //         .transaction(TransactionId::Hash(*transaction_hash))
-        //         .await
-        //     {
-        //         Ok(Some(tx)) => Ok(tx),
-        //         Ok(None) => Err(Error::TxResponse(format!(
-        //             "Transaction hash {} not found",
-        //             transaction_hash
-        //         ))),
-        //         Err(error) => Err(Error::TxResponse(error.to_string())),
-        //     };
+    // todo!()
+    // for transaction_hash in &block.transactions {
+    //     let tx = match self
+    //         .web3
+    //         .eth()
+    //         .transaction(TransactionId::Hash(*transaction_hash))
+    //         .await
+    //     {
+    //         Ok(Some(tx)) => Ok(tx),
+    //         Ok(None) => Err(Error::TxResponse(format!(
+    //             "Transaction hash {} not found",
+    //             transaction_hash
+    //         ))),
+    //         Err(error) => Err(Error::TxResponse(error.to_string())),
+    //     };
 
-        //     match tx.unwrap().to {
-        //         Some(addr) => match &self.web3.eth().code(addr, None).await {
-        //             Ok(code) => {
-        //                 if code == &web3::types::Bytes::from([]) {
-        //                     // "Empty code, skipping
-        //                     continue;
-        //                 } else {
-        //                     // "Non empty code, this address has bytecode we have retrieved
-        //                     // Attempt to initialise an instance of an ERC20 contract at this
-        //                     // address
-        //                     let smart_contract = self.initialise_contract(addr).unwrap();
-        //                     let token_name: String =
-        //                         self.get_token_name(&smart_contract).await.unwrap();
+    //     match tx.unwrap().to {
+    //         Some(addr) => match &self.web3.eth().code(addr, None).await {
+    //             Ok(code) => {
+    //                 if code == &web3::types::Bytes::from([]) {
+    //                     // "Empty code, skipping
+    //                     continue;
+    //                 } else {
+    //                     // "Non empty code, this address has bytecode we have retrieved
+    //                     // Attempt to initialise an instance of an ERC20 contract at this
+    //                     // address
+    //                     let smart_contract = self.initialise_contract(addr).unwrap();
+    //                     let token_name: String =
+    //                         self.get_token_name(&smart_contract).await.unwrap();
 
-        //                     // Attempt to get and print the total supply of an ERC20-compliant
-        //                     // contract
-        //                     let total_supply: Uint =
-        //                         self.total_supply(&smart_contract).await.unwrap();
+    //                     // Attempt to get and print the total supply of an ERC20-compliant
+    //                     // contract
+    //                     let total_supply: Uint =
+    //                         self.total_supply(&smart_contract).await.unwrap();
 
-        //                     info!("token name {:#?}", token_name);
-        //                     info!("token supply {:#?}", total_supply);
-        //                 }
-        //             }
-        //             _ => {
-        //                 continue;
-        //             }
-        //         },
-        //         _ => {
-        //             info!("To address is not a valid address, skipping.");
-        //             continue;
-        //         }
-        //     }
-        // }
+    //                     info!("token name {:#?}", token_name);
+    //                     info!("token supply {:#?}", total_supply);
+    //                 }
+    //             }
+    //             _ => {
+    //                 continue;
+    //             }
+    //         },
+    //         _ => {
+    //             info!("To address is not a valid address, skipping.");
+    //             continue;
+    //         }
+    //     }
+    // }
     // }
 
     /// Filters a block for all ERC-20 compliant transactions
     /// This leverages the standardised ERC20 Application Binary Interface
     // async fn smart_contract_transactions(&self, block: &web3::types::Block<H256>) {
-        // for transaction_hash in &block.transactions {
-        //     let tx = match self
-        //         .ethers()
-        //         .get_transaction(ethers::types::Transaction)
-        //         .await
-        //     {
-        //         Ok(tx) => Ok(tx),
-        //         Err(error) => Err(Error::TxResponse(error.to_string())),
-        //         Ok(None) => Err(Error::TxResponse(format!(
-        //             "Transaction hash {} not found",
-        //             transaction_hash
-        //         ))),
-        //     };
-        //     info!("transaction data {:#?}", tx);
-        //     // TODO(AS): refactor this to uncomment this section or handle the way needeed for first public release version
-        //     // let smart_contract_addr = match tx.unwrap().to {
-        //     //     Some(addr) => match &self.web3.eth().code(addr,
-        //     // None).await {         Ok(code) => {
-        //     //             if code == &web3::types::Bytes::from([]) {
-        //     //                 // "Empty code, skipping
-        //     //                 continue;
-        //     //             } else {
-        //     //                 // "Non empty code, this address has bytecode
-        //     // we have retrieved                 // Attempt
-        //     // to initialise an instance of an ERC20 contract at this
-        //     //                 // address
-        //     //                 let smart_contract =
-        //     // self.initialise_contract(addr).unwrap();
-        //     //                 let token_name: String =
-        //     //
-        //     // self.get_token_name(&smart_contract).await.unwrap();
+    // for transaction_hash in &block.transactions {
+    //     let tx = match self
+    //         .ethers()
+    //         .get_transaction(ethers::types::Transaction)
+    //         .await
+    //     {
+    //         Ok(tx) => Ok(tx),
+    //         Err(error) => Err(Error::TxResponse(error.to_string())),
+    //         Ok(None) => Err(Error::TxResponse(format!(
+    //             "Transaction hash {} not found",
+    //             transaction_hash
+    //         ))),
+    //     };
+    //     info!("transaction data {:#?}", tx);
+    //     // TODO(AS): refactor this to uncomment this section or handle the way needeed for first public release version
+    //     // let smart_contract_addr = match tx.unwrap().to {
+    //     //     Some(addr) => match &self.web3.eth().code(addr,
+    //     // None).await {         Ok(code) => {
+    //     //             if code == &web3::types::Bytes::from([]) {
+    //     //                 // "Empty code, skipping
+    //     //                 continue;
+    //     //             } else {
+    //     //                 // "Non empty code, this address has bytecode
+    //     // we have retrieved                 // Attempt
+    //     // to initialise an instance of an ERC20 contract at this
+    //     //                 // address
+    //     //                 let smart_contract =
+    //     // self.initialise_contract(addr).unwrap();
+    //     //                 let token_name: String =
+    //     //
+    //     // self.get_token_name(&smart_contract).await.unwrap();
 
-        //     //                 // Attempt to get and print the total supply
-        //     // of an ERC20-compliant                 //
-        //     // contract                 let total_supply:
-        //     // Uint =
-        //     // self.total_supply(&smart_contract).await.unwrap();
+    //     //                 // Attempt to get and print the total supply
+    //     // of an ERC20-compliant                 //
+    //     // contract                 let total_supply:
+    //     // Uint =
+    //     // self.total_supply(&smart_contract).await.unwrap();
 
-        //     //                 info!("token name {:#?}", token_name);
-        //     //                 info!("token supply {:#?}", total_supply);
-        //     //             }
-        //     //         }
-        //     //         _ => {
-        //     //             continue;
-        //     //         }
-        //     //     },
-        //     //     _ => {
-        //     //         // info!("To address is not a valid address,
-        //     // skipping.");         continue;
-        //     //     }
-        //     // };
-        // }
-        // // info!("{:#?}", smart_contract_addr);
+    //     //                 info!("token name {:#?}", token_name);
+    //     //                 info!("token supply {:#?}", total_supply);
+    //     //             }
+    //     //         }
+    //     //         _ => {
+    //     //             continue;
+    //     //         }
+    //     //     },
+    //     //     _ => {
+    //     //         // info!("To address is not a valid address,
+    //     // skipping.");         continue;
+    //     //     }
+    //     // };
+    // }
+    // // info!("{:#?}", smart_contract_addr);
     // }
 
     /// Given a specified address, retrieves the [Ethereum balance][EthereumAmount] of that
@@ -253,7 +247,7 @@ impl EthClient {
 
     /// Given a specified contract instance, determine the total supply of
     /// tokens
-    // TODO: Migrate 
+    // TODO: Migrate
     // async fn total_supply(
     //     &self,
     //     smart_contract: &web3::contract::Contract<Http>,
@@ -307,13 +301,15 @@ impl EthClient {
     pub async fn latest_block(&self) -> Result<Block<Transaction>, Error> {
         let block_data = &self
             .ethers
-            .get_block_with_txs(ethers::types::BlockId::Number(ethers::types::BlockNumber::Latest))
+            .get_block_with_txs(ethers::types::BlockId::Number(
+                ethers::types::BlockNumber::Latest,
+            ))
             .await
             .unwrap()
             .unwrap();
 
         let output_block_data = block_data.clone();
-        Ok(output_block_data)        
+        Ok(output_block_data)
         // let block_data = &self
         //     .web3
         //     .eth()
@@ -353,12 +349,7 @@ impl EthClient {
         // we're using a string because U64 is a web3 type
         let block_number = block_id.parse::<U64>().unwrap();
         let blockid = BlockNumber::Number(block_number);
-        let block_data = &self
-            .ethers()
-            .get_block(blockid)
-            .await
-            .unwrap()
-            .unwrap();
+        let block_data = &self.ethers().get_block(blockid).await.unwrap().unwrap();
         let output_block_data = block_data.clone();
         Ok(output_block_data)
     }

--- a/coins/ethereum/src/ethereum_amount.rs
+++ b/coins/ethereum/src/ethereum_amount.rs
@@ -99,3 +99,4 @@ impl CryptoAmount for EthereumAmount {
         self.wei.as_u64()
     }
 }
+s

--- a/coins/ethereum/src/ethereum_amount.rs
+++ b/coins/ethereum/src/ethereum_amount.rs
@@ -1,7 +1,9 @@
 use crate::Error;
 use std::ops;
 use walletd_coin_core::CryptoAmount;
-use web3::ethabi::ethereum_types::U256;
+use web3::ethabi::ethereum_types::U256 as oldU256;
+use ethers::types::U256;
+
 
 /// Contains a field representing the amount of wei in the amount. Also has functions to convert to and from the main unit (ETH) and the smallest unit (wei).
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
@@ -99,4 +101,3 @@ impl CryptoAmount for EthereumAmount {
         self.wei.as_u64()
     }
 }
-s

--- a/coins/ethereum/src/ethereum_amount.rs
+++ b/coins/ethereum/src/ethereum_amount.rs
@@ -1,7 +1,6 @@
 use crate::Error;
 use std::ops;
 use walletd_coin_core::CryptoAmount;
-use web3::ethabi::ethereum_types::U256 as oldU256;
 use ethers::types::U256;
 
 

--- a/coins/ethereum/src/ethereum_amount.rs
+++ b/coins/ethereum/src/ethereum_amount.rs
@@ -1,8 +1,7 @@
 use crate::Error;
+use ethers::types::U256;
 use std::ops;
 use walletd_coin_core::CryptoAmount;
-use ethers::types::U256;
-
 
 /// Contains a field representing the amount of wei in the amount. Also has functions to convert to and from the main unit (ETH) and the smallest unit (wei).
 #[derive(Default, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -2,28 +2,23 @@ use ::core::fmt;
 use std::fmt::LowerHex;
 use std::str::FromStr;
 
+use crate::{EthereumAmount, EthereumFormat};
 use crate::Error;
 use crate::EthClient;
+
+use ethers::prelude::*;
+// use ethers::providers::{Middleware};
+// use ethers::types::{TransactionRequest};
+// use ethers::signers::{Signer};
 use secp256k1::{PublicKey, SecretKey};
 use tiny_keccak::{Hasher, Keccak};
 use walletd_bip39::Seed;
 use walletd_hd_key::{slip44, HDKey, HDNetworkType, HDPath, HDPathBuilder, HDPurpose};
-//use web3::types::{Address, TransactionParameters};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 
-use crate::{EthereumAmount, EthereumFormat};
 
 
-use ethers::prelude::*;
-use ethers::providers::{Middleware};
-
-use ethers::types::{TransactionRequest};
-
-
-
-
-use ethers::signers::{Signer};
 
 /// Represents a private key for an Ethereum wallet, wraps a [SecretKey] from the secp256k1 crate
 #[derive(Debug, Clone)]
@@ -202,9 +197,9 @@ impl EthereumWalletBuilder {
         hd_path_builder
             .purpose_index(hd_purpose_num)
             .hardened_purpose()
-            .coin_type_index(coin_type_id)
+            .coin_type_index(coin_type_id)            
             .hardened_coin_type();
-
+        
         let derived_key = master_hd_key.derive(&hd_path_builder.build().to_string())?;
         
         let private_key: EthereumPrivateKey =
@@ -223,6 +218,7 @@ impl EthereumWalletBuilder {
         println!("{:?}", public_key);
         println!("{:?}", private_key);
         println!("{:?}", derived_key);
+        //EthereumWallet::set_blockchain_client(client);
 
         let wallet = EthereumWallet {
             address_format: self.address_format,
@@ -233,7 +229,7 @@ impl EthereumWalletBuilder {
             blockchain_client: None,
             derived_hd_key: Some(derived_key),
         };
-        println!("wallet: {:?}", wallet);
+        //println!("wallet: {:?}", wallet);
         Ok(wallet)
     }
 
@@ -306,7 +302,7 @@ impl EthereumWallet {
     // TODO: take chain_id as a parameter
     // TODO: Take index as a parameter and use that for deriving the wallet we want (refactor keystore)
     /// This function creates and broadcasts a basic Ethereum transfer transaction to the Ethereum mempool.
-    async fn transfer(
+    pub async fn transfer(
         &self,
         _send_amount: EthereumAmount,
         _to_address: &str,

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -144,6 +144,7 @@ pub struct EthereumWalletBuilder {
     network_type: HDNetworkType,
     #[zeroize(skip)]
     hd_path_builder: HDPathBuilder,
+    chain_id: u64,
 }
 
 impl Default for EthereumWalletBuilder {
@@ -163,6 +164,7 @@ impl Default for EthereumWalletBuilder {
             mnemonic_seed: None,
             network_type: HDNetworkType::MainNet,
             hd_path_builder,
+            chain_id: 5, // Goerli
         }
     }
 }
@@ -304,6 +306,7 @@ impl EthereumWallet {
         // Instantiate wallet using the private key's secret bytes
         let wallet_from_bytes = Wallet::from_bytes(&secret_bytes).unwrap();
 
+
         let provider = &self.blockchain_client().unwrap().ethers();
 
         // Instantiate a ethers local wallet from the wallet's secret bytes
@@ -318,7 +321,7 @@ impl EthereumWallet {
             .gas(21000)
             .value(send_amount.wei())
             .chain_id(5u64);
-        
+
         let pending_tx = client.send_transaction(tx, None).await.unwrap();
         let receipt = pending_tx
             .await

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -1,4 +1,4 @@
-use core::fmt;
+use ::core::fmt;
 use std::fmt::LowerHex;
 use std::str::FromStr;
 
@@ -10,10 +10,17 @@ use tiny_keccak::{Hasher, Keccak};
 use walletd_bip39::Seed;
 use walletd_coin_core::{CryptoWallet, CryptoWalletBuilder};
 use walletd_hd_key::{slip44, HDKey, HDNetworkType, HDPath, HDPathBuilder, HDPurpose};
-use web3::types::{Address, TransactionParameters};
+//use web3::types::{Address, TransactionParameters};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{EthereumAmount, EthereumFormat};
+
+use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
+use ethers::prelude::*;
+use ethers::providers::{Middleware, Provider};
+use ethers::providers::Http as ethersHttp;
+use ethers::types::{Address, TransactionRequest, U256};
+use ethers::types::{BlockId, Block, BlockNumber, H160, H256, U64};
 
 /// Represents a private key for an Ethereum wallet, wraps a [SecretKey] from the secp256k1 crate
 #[derive(Debug, Clone)]
@@ -281,7 +288,7 @@ impl CryptoWallet for EthereumWallet {
 
     async fn balance(&self) -> Result<Self::CryptoAmount, Error> {
         let blockchain_client = self.blockchain_client()?;
-        let address = web3::types::H160::from_str(&self.public_address())
+        let address = ethers::types::Address::from_str(&self.public_address())
             .map_err(|e| (Error::FromStr(e.to_string())))?;
         let balance = blockchain_client.balance(address).await?;
         Ok(balance)
@@ -292,33 +299,36 @@ impl CryptoWallet for EthereumWallet {
         send_amount: &Self::CryptoAmount,
         to_address: &str,
     ) -> Result<String, Error> {
-        let blockchain_client = self.blockchain_client()?;
-        let to = Address::from_str(to_address).map_err(|e| Error::FromStr(e.to_string()))?;
-        let amount = send_amount.wei();
+        todo!()
 
-        let tx_object = TransactionParameters {
-            to: Some(to),
-            value: amount,
-            ..Default::default()
-        };
+        // let blockchain_client = self.blockchain_client()?;
+        // let to = Address::from_str(to_address).map_err(|e| Error::FromStr(e.to_string()))?;
+        // let amount: ethers::types::U256 = send_amount.wei();
 
-        let secret_key = self.private_key()?.0;
+        // // TODO for Ethers
+        // let tx_object = TransactionParameters {
+        //     to: Some(to),
+        //     value: amount,
+        //     ..Default::default()
+        // };
 
-        // sign the tx
-        let signed = blockchain_client
-            .web3()
-            .accounts()
-            .sign_transaction(tx_object, &secret_key)
-            .await?;
+        // let secret_key = self.private_key()?.0;
 
-        let result = blockchain_client
-            .eth()
-            .send_raw_transaction(signed.raw_transaction)
-            .await?;
+        // // sign the tx
+        // let signed = blockchain_client
+        //     .ethers()
+        //     .accounts()
+        //     .sign_transaction(tx_object, &secret_key)
+        //     .await?;
 
-        let hash = hex::encode(result.as_bytes());
+        // let result = blockchain_client
+        //     .eth()
+        //     .send_raw_transaction(signed.raw_transaction)
+        //     .await?;
 
-        Ok(hash)
+        // let hash = hex::encode(result.as_bytes());
+
+        // Ok(hash)
     }
 
     fn set_blockchain_client(&mut self, client: Self::BlockchainClient) {

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -288,8 +288,8 @@ impl EthereumWallet {
     /// This function creates and broadcasts a basic Ethereum transfer transaction to the Ethereum mempool.
     pub async fn transfer(
         &self,
-        _send_amount: EthereumAmount,
-        _to_address: &str,
+        send_amount: EthereumAmount,
+        to_address: &str,
     ) -> Result<String, Error> {
         //let secret_key: &Result<EthereumPrivateKey, Error> = &self.private_key();
 
@@ -312,14 +312,13 @@ impl EthereumWallet {
 
         // Link our wallet instance to our provider for signing our transactions
         let client = SignerMiddleware::new(provider, wallet_from_bytes.with_chain_id(5u64));
-
         // Create a transaction request to send 10000 wei to the Goerli address
         let tx = TransactionRequest::new()
-            .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
+            .to(to_address)
             .gas(21000)
-            .value(10000)
+            .value(send_amount.wei())
             .chain_id(5u64);
-
+        
         let pending_tx = client.send_transaction(tx, None).await.unwrap();
         let receipt = pending_tx
             .await

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -362,6 +362,11 @@ impl EthereumWallet {
         self.public_address.clone()
     }
 
+    /// A convenience method for retrieving the string of a public_address
+    pub fn address(&self) -> String {
+        return self.public_address().to_string();
+    }
+
     /// Returns the network type used by the wallet
     pub fn network(&self) -> HDNetworkType {
         self.network

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -305,14 +305,14 @@ impl EthereumWallet {
 
     // TODO: take chain_id as a parameter
     // TODO: Take index as a parameter and use that for deriving the wallet we want (refactor keystore)
-    /// Creates and sends a transfer transaction to the Ethereum blockchain.
+    /// This function creates and broadcasts a basic Ethereum transfer transaction to the Ethereum mempool.
     async fn transfer(
         &self,
-        _send_amount: &Self::CryptoAmount,
+        _send_amount: EthereumAmount,
         _to_address: &str,
     ) -> Result<String, Error> {
 
-        let secret_key: &Result<EthereumPrivateKey, Error> = &self.private_key();
+        //let secret_key: &Result<EthereumPrivateKey, Error> = &self.private_key();
 
         let derived_hd_key = &self.derived_hd_key()?;
         let private_key =
@@ -349,118 +349,6 @@ impl EthereumWallet {
         
         let _tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
         Ok("tx_id".to_string())
-        // let wallet: LocalWallet = LocalWallet::from(secret_key).with_chain_id(5);
-        // println!("the wallet {:?}", wallet);
-        // let wallet_nonlocal = MnemonicBuilder::<English>::default()
-        //     .phrase(phrase)
-        //     .index(index)
-        //     .unwrap()
-        //     .build()
-        //     .unwrap();
-        // LocalWallet = Wallet<ethers_core::k256::ecdsa::SigningKey>;
-        // let secp = Secp256k1::new();
-        // let (secret_key, public_key) = secp.generate_keypair(&mut OsRng);
-
-        //let local_wallet = LocalWallet::from() 
-        // let key = "4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318"
-        //     .parse::<LocalWallet>()
-        //     .unwrap();
-        // println!("{:?}", &wallet_nonlocal);
-        
-
-        // 
-        // let ourhdkey = &self.derived_hd_key()?;
-
-        // let key_we_want: &SecretKey = &private_key.0;
-        // let public_key: &EthereumPublicKey = &self.public_key()?;
-        // let private_key = self.private_key()?.0;
-
-        // let derived = &self.master_hd_key()?;
-        // println!("derived: {:?}", derived);
-        // //let wallet_nonlocal = LocalWallet::from(key_we_want.clone());
-        // // a2fd9c0522d84d52ee4c8533dc02d4b69b4df9b6255e1af20c9f1d4d691689f2a38637eb1ec778972bf845c32d5ae83c7536999b5666397ac32021b21e0accee
-        // // 6ccb54994cfdc2f95895b51989f0fcaa37266421c6ec39dbdc3f2026209efd83988a9b19d7ea245fde0de423d5af973d733c4dc317dc551ca5fdecad4bd47447
-        // // println!("wallet_nonlocal: {:?}", wallet_nonlocal);
-
-        // //let Wallet = Wallet::from(private_key).unwrap();
-
-        // //println!("Wallet: {:?}", Wallet);
-
-        // // println!("kww: {:?}", key_we_want);
-        // // println!("{:?}", private_key);
-        // // println!("{:?}", &self);
-        // // println!("private key: {:?}", &self.private_key());
-        // let test = private_key.clone();
-        // // println!("test: {:?}", test);
-        // // let secret_key = test.unwrap();
-
-        // // let wallet_nonlocal: Wallet = Wallet::from(&test); 
-        // let wallet = LocalWallet::new(&mut thread_rng());
-        // let test2 = &mut thread_rng();
-        // // println!("thread_rng: {:?}", test2);
-
-        
-        // // let blockchain_client = self.blockchain_client()?;
-        // let to = Address::from_str(to_address).map_err(|e| Error::FromStr(e.to_string()))?;
-        // let amount: ethers::types::U256 = send_amount.wei();
-
-        // // // TODO for Ethers
-        // // let tx_object = TransactionParameters {
-        // //     to: Some(to),
-        // //     value: amount,
-        // //     ..Default::default()
-        // // };
-        
-        // let tx = ethers::types::TransactionRequest::new()
-        //     .to("0x681dA56258fF429026449F1435aE87e1B6e9F85b")
-        //     .gas(21000)
-        //     .value(10000);
-
-        
-
-        // // let wallet: LocalWallet = EthersWallet::from_bytes(&private_key.to_bytes()).unwrap();
-        // // println!("wallet: {:?}", wallet);
-
-        // let i = &self.index(0);
-        // println!("i: {:?}", i);
-
-        // let derived_hd_key = &self.derived_hd_key()?;
-        // //println!("account_deriv_path: {:?}", &account_deriv_path);
-        // println!("self: {:?}", &self);
-
-        // println!("master hd key {:?}", &self.master_hd_key());
-        // println!("derived hd key {:?}", derived_hd_key);
-        
-        // println!("derived: {:?}", derived);
-        // //println!("address derivation path: {}", address_derivation_path);
-
-        // let eth_first_account_key = &self.master_hd_key().unwrap().derive("m/44'/60'/0'/0")?;
-        // // the master seed should be the same for a child HD Key and it's parent HD Key
-
-        // println!("{:?}", eth_first_account_key);
-        // println!(
-        //     "eth_first_account_key depth {} {:?}",
-        //     eth_first_account_key.depth(),
-        //     eth_first_account_key.extended_private_key()
-        // );
-        // let secret_key = self.private_key()?.0;
-        // println!("{:?}", secret_key);
-        // let signed = &self.blockchain_client()?.ethers().sign_transaction(&tx, &secret_key).await.unwrap();
-            // .ethers()
-            // .accounts()
-            // .sign_transaction(tx_object, &secret_key)
-            // .await?;
-
-        // // sign the tx
-
-        // let result = blockchain_client
-        //     .eth()
-        //     .send_raw_transaction(signed.raw_transaction)
-        //     .await?;
-
-        // let hash = hex::encode(result.as_bytes());
-
-        // Ok(hash)
     }
     /// Set the Blockchain Client on the Wallet
     pub fn set_blockchain_client(&mut self, client: EthClient) {

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -12,20 +12,20 @@ use walletd_coin_core::{CryptoWallet, CryptoWalletBuilder};
 use walletd_hd_key::{slip44, HDKey, HDNetworkType, HDPath, HDPathBuilder, HDPurpose};
 //use web3::types::{Address, TransactionParameters};
 use zeroize::{Zeroize, ZeroizeOnDrop};
-use walletd_hd_key::prelude::*;
-use walletd_hd_key::slip44::{Coin, Symbol};
+
+
 use crate::{EthereumAmount, EthereumFormat};
 
-use web3::types::{ H160 as oldH160, H256 as oldH256, U64 as oldU64};
-use ethers::prelude::*;
-use ethers::providers::{Middleware, Provider};
-use ethers::providers::Http as ethersHttp;
-use ethers::types::{Address, TransactionRequest, U256};
-use ethers::types::{BlockId, Block, BlockNumber, H160, H256, U64};
-use ethers::signers::Wallet as EthersWallet;
 
-use ethers::core::rand::thread_rng;
-use ethers::signers::{LocalWallet, Signer};
+use ethers::prelude::*;
+use ethers::providers::{Middleware};
+
+use ethers::types::{TransactionRequest};
+
+
+
+
+use ethers::signers::{Signer};
 
 /// Represents a private key for an Ethereum wallet, wraps a [SecretKey] from the secp256k1 crate
 #[derive(Debug, Clone)]
@@ -317,8 +317,8 @@ impl CryptoWallet for EthereumWallet {
     // TODO: Take index as a parameter and use that for deriving the wallet we want (refactor keystore)
     async fn transfer(
         &self,
-        send_amount: &Self::CryptoAmount,
-        to_address: &str,
+        _send_amount: &Self::CryptoAmount,
+        _to_address: &str,
     ) -> Result<String, Error> {
         println!("self: {:?}", &self);
         let secret_key: &Result<EthereumPrivateKey, Error> = &self.private_key();
@@ -327,7 +327,7 @@ impl CryptoWallet for EthereumWallet {
         let derived_hd_key = &self.derived_hd_key()?;
         let private_key =
                 EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
-        let address_derivation_path = &derived_hd_key.derivation_path.clone();
+        let _address_derivation_path = &derived_hd_key.derivation_path.clone();
         
         // EthereumWallet stores the private key as a 32 byte array
         let secret_bytes = private_key.to_bytes();
@@ -356,7 +356,7 @@ impl CryptoWallet for EthereumWallet {
         let pending_tx = client.send_transaction(tx, None).await.unwrap();
         let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
         
-        let tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
+        let _tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
         Ok("tx_id".to_string())
         // let wallet: LocalWallet = LocalWallet::from(secret_key).with_chain_id(5);
         // println!("the wallet {:?}", wallet);
@@ -505,12 +505,12 @@ impl EthereumWallet {
 
     /// A convenience method for retrieving the string of a public_address
     pub fn address(&self) -> String {
-        return self.public_address().to_string();
+        self.public_address()
     }
 
     /// Return the pub/priv keys at a specified index
     /// For now, we're assuming that the path we're using for derivation is the default (m/44'/60'/0'/0/{index})
-    pub fn index(&self, index: u64) -> (String, String) {
+    pub fn index(&self, _index: u64) -> (String, String) {
         
         // // A wallet 
 

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -187,7 +187,7 @@ impl EthereumWalletBuilder {
             (Some(key), _) => key.clone(),
             (None, Some(seed)) => HDKey::new_master(seed.clone(), self.network_type)?,
         };
-        println!("{:?}", &self.mnemonic_seed);
+
         let hd_purpose_num = self
             .hd_path_builder
             .purpose
@@ -204,21 +204,10 @@ impl EthereumWalletBuilder {
         
         let private_key: EthereumPrivateKey =
             EthereumPrivateKey::from_slice(&derived_key.extended_private_key()?.to_bytes())?;
-        println!("pk: {:?}", private_key);
-
-        let private_key2 = &derived_key.extended_private_key_serialized().unwrap();
-        println!("pk2: {:?}", private_key2);
-
+        
         let public_key =
             EthereumPublicKey::from_slice(&derived_key.extended_public_key()?.to_bytes())?;
         let public_address = public_key.to_public_address(self.address_format)?;
-        println!("public k 3: {:?}", public_key);
-
-        println!("We want this for signing:");
-        println!("{:?}", public_key);
-        println!("{:?}", private_key);
-        println!("{:?}", derived_key);
-        //EthereumWallet::set_blockchain_client(client);
 
         let wallet = EthereumWallet {
             address_format: self.address_format,
@@ -228,8 +217,7 @@ impl EthereumWalletBuilder {
             network: master_hd_key.network(),
             blockchain_client: None,
             derived_hd_key: Some(derived_key),
-        };
-        //println!("wallet: {:?}", wallet);
+        };        
         Ok(wallet)
     }
 
@@ -336,9 +324,6 @@ impl EthereumWallet {
             .gas(21000)
             .value(10000)
             .chain_id(5u64);
-
-
-        println!("Initialising send: {:?}", &tx);
         
         let pending_tx = client.send_transaction(tx, None).await.unwrap();
         let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
@@ -422,7 +407,6 @@ impl EthereumWallet {
 
     /// Returns the private key of the wallet if it exists, otherwise returns an error
     pub fn private_key(&self) -> Result<EthereumPrivateKey, Error> {
-        println!("{:?}", &self.private_key);
         if let Some(key) = self.private_key.clone() {
             Ok(key)
         } else {

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -305,7 +305,7 @@ impl EthereumWallet {
 
         // Retrieve instance of blockchain connector (provider) using the private key's secret bytes
         let provider = &self.blockchain_client().unwrap().ethers();
-        
+
         // Instantiate a ethers local wallet from the wallet's secret bytes
         let wallet_from_bytes = Wallet::from_bytes(&secret_bytes).unwrap();
 

--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -2,9 +2,9 @@ use ::core::fmt;
 use std::fmt::LowerHex;
 use std::str::FromStr;
 
-use crate::{EthereumAmount, EthereumFormat};
 use crate::Error;
 use crate::EthClient;
+use crate::{EthereumAmount, EthereumFormat};
 
 use ethers::prelude::*;
 // use ethers::providers::{Middleware};
@@ -15,10 +15,6 @@ use tiny_keccak::{Hasher, Keccak};
 use walletd_bip39::Seed;
 use walletd_hd_key::{slip44, HDKey, HDNetworkType, HDPath, HDPathBuilder, HDPurpose};
 use zeroize::{Zeroize, ZeroizeOnDrop};
-
-
-
-
 
 /// Represents a private key for an Ethereum wallet, wraps a [SecretKey] from the secp256k1 crate
 #[derive(Debug, Clone)]
@@ -197,14 +193,14 @@ impl EthereumWalletBuilder {
         hd_path_builder
             .purpose_index(hd_purpose_num)
             .hardened_purpose()
-            .coin_type_index(coin_type_id)            
+            .coin_type_index(coin_type_id)
             .hardened_coin_type();
-        
+
         let derived_key = master_hd_key.derive(&hd_path_builder.build().to_string())?;
-        
+
         let private_key: EthereumPrivateKey =
             EthereumPrivateKey::from_slice(&derived_key.extended_private_key()?.to_bytes())?;
-        
+
         let public_key =
             EthereumPublicKey::from_slice(&derived_key.extended_public_key()?.to_bytes())?;
         let public_address = public_key.to_public_address(self.address_format)?;
@@ -217,7 +213,7 @@ impl EthereumWalletBuilder {
             network: master_hd_key.network(),
             blockchain_client: None,
             derived_hd_key: Some(derived_key),
-        };        
+        };
         Ok(wallet)
     }
 
@@ -295,14 +291,13 @@ impl EthereumWallet {
         _send_amount: EthereumAmount,
         _to_address: &str,
     ) -> Result<String, Error> {
-
         //let secret_key: &Result<EthereumPrivateKey, Error> = &self.private_key();
 
         let derived_hd_key = &self.derived_hd_key()?;
         let private_key =
-                EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
+            EthereumPrivateKey::from_slice(&derived_hd_key.extended_private_key()?.to_bytes())?;
         let _address_derivation_path = &derived_hd_key.derivation_path.clone();
-        
+
         // EthereumWallet stores the private key as a 32 byte array
         let secret_bytes = private_key.to_bytes();
 
@@ -313,10 +308,10 @@ impl EthereumWallet {
 
         // Instantiate a ethers local wallet from the wallet's secret bytes
 
-        // 5 = goerli chain id 
+        // 5 = goerli chain id
 
         // Link our wallet instance to our provider for signing our transactions
-        let client = SignerMiddleware::new(provider, wallet_from_bytes.with_chain_id(5u64));    
+        let client = SignerMiddleware::new(provider, wallet_from_bytes.with_chain_id(5u64));
 
         // Create a transaction request to send 10000 wei to the Goerli address
         let tx = TransactionRequest::new()
@@ -324,11 +319,18 @@ impl EthereumWallet {
             .gas(21000)
             .value(10000)
             .chain_id(5u64);
-        
+
         let pending_tx = client.send_transaction(tx, None).await.unwrap();
-        let receipt = pending_tx.await.unwrap().ok_or_else(|| println!("tx dropped from mempool")).unwrap();
-        
-        let _tx = client.get_transaction(receipt.transaction_hash).await.unwrap();
+        let receipt = pending_tx
+            .await
+            .unwrap()
+            .ok_or_else(|| println!("tx dropped from mempool"))
+            .unwrap();
+
+        let _tx = client
+            .get_transaction(receipt.transaction_hash)
+            .await
+            .unwrap();
         Ok("tx_id".to_string())
     }
     /// Set the Blockchain Client on the Wallet
@@ -369,14 +371,13 @@ impl EthereumWallet {
     /// Return the pub/priv keys at a specified index
     /// For now, we're assuming that the path we're using for derivation is the default (m/44'/60'/0'/0/{index})
     pub fn index(&self, _index: u64) -> (String, String) {
-        
-        // // A wallet 
+        // // A wallet
 
         // let account_deriv_path = HDPath::builder()
         //     .purpose_index(HDPurpose::BIP44.to_shortform_num()) // 44' for Eth
         //     .coin_type_index(Coin::from(Symbol::ETH).id()) // 60' for Eth
         //     .account_index(0) // we'll work from acc 0
-        //     .change_index(0) 
+        //     .change_index(0)
         //     .no_address_index()
         //     .build().to_string();
 

--- a/coins/ethereum/src/lib.rs
+++ b/coins/ethereum/src/lib.rs
@@ -122,7 +122,7 @@ pub use ethereum_wallet::{
 };
 mod error;
 pub use error::Error;
-pub use web3;
+pub use ethers;
 pub mod prelude;
 pub use walletd_bip39::{
     Bip39Language, Bip39Mnemonic, Bip39MnemonicType, Mnemonic, MnemonicBuilder, Seed,

--- a/coins/ethereum/src/prelude.rs
+++ b/coins/ethereum/src/prelude.rs
@@ -7,7 +7,7 @@
 
 pub use crate::{
     EthClient, EthereumAmount, EthereumFormat, EthereumPrivateKey, EthereumPublicKey,
-    EthereumWallet, EthereumWalletBuilder, 
+    EthereumWallet, EthereumWalletBuilder,
 };
 
 pub use ethers::types::Transaction;

--- a/coins/ethereum/src/prelude.rs
+++ b/coins/ethereum/src/prelude.rs
@@ -7,6 +7,8 @@
 
 pub use crate::{
     EthClient, EthereumAmount, EthereumFormat, EthereumPrivateKey, EthereumPublicKey,
-    EthereumWallet, EthereumWalletBuilder,
+    EthereumWallet, EthereumWalletBuilder, 
 };
+
+pub use ethers::types::Transaction;
 pub use walletd_coin_core::prelude::*;


### PR DESCRIPTION
This PR is largely in a draft state, with support for smart contracts left unimplemented. 

I expressly seek feedback on the differences between how web3.rs and ethers.rs facilitate the sending of transactions.

These can be seen by looking at coins/examples/send_funds.rs, which can be run the from the CLI using the command 

`cargo run --example send_funds`

The difference between these two processes is largely that ethers moves to a middleware-based scheme where you need to link a distinct wallet to a distinct "provider" (blockchainconnector, to use our definitions). I want to discuss how we approach signing methods, as well as discuss whether some of the techniques we see in ethers may be techniques we want to look at implementing at large.
