### PR TITLE
refactor: moved the ethclient out of the wallet

### DIFF
--- a/coins/ethereum/examples/eth_quickstart_guide.rs
+++ b/coins/ethereum/examples/eth_quickstart_guide.rs
@@ -23,7 +23,7 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     // let xpub = ExtendedPubKey::from_priv(&secp, &child);
     // println!("Public key at {}: {}", path, xpub);
     let mnemonic = Mnemonic::parse(mnemonic_phrase).unwrap();
-    let mut ethereum_wallet = EthereumWallet::builder()
+    let ethereum_wallet = EthereumWallet::builder()
         .mnemonic(mnemonic.clone())
         .build()?;
 
@@ -44,8 +44,7 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
     println!("Block number: {:#?}", block_number);
     println!("Gas price: {:#?}", gas_price);
     println!("transaction data: {:?}", tx);
-    ethereum_wallet.set_blockchain_client(eth_client);
-    let balance = ethereum_wallet.balance().await?;
+    let balance = ethereum_wallet.balance(&eth_client).await?;
     println!(
         "ethereum wallet balance: {} ETH, ({} wei)",
         balance.eth(),

--- a/coins/ethereum/examples/send_funds.rs
+++ b/coins/ethereum/examples/send_funds.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
 
     println!("blockchain_client: {:?}", &blockchain_client);
 
-    let mut wallet = EthereumWallet::builder()
+    let wallet = EthereumWallet::builder()
         .mnemonic(mnemonic)
         .network_type(HDNetworkType::TestNet)
         .build()
@@ -30,9 +30,10 @@ async fn main() -> Result<(), walletd_ethereum::Error> {
         .unwrap();
     print!("balance: {:?}", &balance);
 
-    wallet.set_blockchain_client(blockchain_client.clone());
     let send_amount = EthereumAmount::from_wei(10000.into());
-    let tx = wallet.transfer(send_amount, GOERLI_TEST_ADDRESS).await?;
+    let tx = wallet
+        .transfer(&blockchain_client, send_amount, GOERLI_TEST_ADDRESS)
+        .await?;
 
     println!("tx: {:?}", &tx);
     Ok(())

--- a/coins/ethereum/src/lib.rs
+++ b/coins/ethereum/src/lib.rs
@@ -43,8 +43,7 @@
 //! let mnemonic = Mnemonic::parse(mnemonic_phrase).unwrap();
 //! let mut ethereum_wallet = EthereumWallet::builder().mnemonic(mnemonic).network_type(HDNetworkType::TestNet).build()?;
 //! let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
-//! let eth_client = EthClient::new(ethclient_url)?;
-//! ethereum_wallet.set_blockchain_client(eth_client);
+//! let _eth_client = EthClient::new(ethclient_url)?;
 //! # Ok(())
 //! # }
 //! ```
@@ -73,11 +72,10 @@
 //! # async fn ethereum() -> Result<(), walletd_ethereum::Error> {
 //! let mnemonic_phrase = "joy tail arena mix other envelope diary achieve short nest true vocal";
 //! let mnemonic = Mnemonic::parse(mnemonic_phrase).unwrap();
-//! let mut ethereum_wallet = EthereumWallet::builder().mnemonic(mnemonic).network_type(HDNetworkType::TestNet).build()?;
+//! let ethereum_wallet = EthereumWallet::builder().mnemonic(mnemonic).network_type(HDNetworkType::TestNet).build()?;
 //! # let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
 //! # let eth_client = EthClient::new(ethclient_url)?;
-//! # ethereum_wallet.set_blockchain_client(eth_client);
-//! let balance = ethereum_wallet.balance().await?;
+//! let balance = ethereum_wallet.balance(&eth_client).await?;
 //! println!("ethereum wallet balance: {} ETH, ({} wei)", balance.eth(), balance.wei());
 //! # Ok(())
 //! # }

--- a/walletd/examples/wd_quickstart_guide.rs
+++ b/walletd/examples/wd_quickstart_guide.rs
@@ -12,6 +12,7 @@ async fn main() -> Result<(), walletd::Error> {
 
     let mut btc_wallet = BitcoinWalletBuilder::new()
         .mnemonic(mnemonic.clone())
+        .network_type(bdk::bitcoin::Network::Testnet)
         .build()
         .unwrap();
 
@@ -23,7 +24,7 @@ async fn main() -> Result<(), walletd::Error> {
         btc_wallet.balance().await?.confirmed
     );
 
-    let mut eth_wallet = EthereumWalletBuilder::new()
+    let eth_wallet = EthereumWalletBuilder::new()
         .mnemonic(mnemonic)
         .network_type(HDNetworkType::TestNet)
         .build()
@@ -31,10 +32,9 @@ async fn main() -> Result<(), walletd::Error> {
     print!("eth_wallet public address: {}", eth_wallet.public_address());
     let eth_client =
         EthClient::new("https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161")?;
-    eth_wallet.set_blockchain_client(eth_client);
     println!(
         "eth_wallet balance: {} ETH",
-        eth_wallet.balance().await?.eth()
+        eth_wallet.balance(&eth_client).await?.eth()
     );
     Ok(())
 }

--- a/walletd/examples/workflow.rs
+++ b/walletd/examples/workflow.rs
@@ -29,13 +29,10 @@ async fn main() -> Result<(), Error> {
     // This is another way to use the builder pattern to create the blockchain client instead of using the pattern written out for the btc_blockchain_client
     let eth_blockchain_client = EthClient::new(ETH_TESTNET_URL.into())?;
 
-    let mut eth_wallet = EthereumWallet::builder()
+    let eth_wallet = EthereumWallet::builder()
         .mnemonic(mnemonic)
         .network_type(HDNetworkType::TestNet)
         .build()?;
-    // let mut eth_wallet = hd_wallet.derive_wallet::<EthereumWallet>()?;
-
-    eth_wallet.set_blockchain_client(eth_blockchain_client);
 
     // Gets the current balances for the BTC wallet and ETH wallet
     let current_btc_balance = btc_wallet.balance().await?;
@@ -43,7 +40,7 @@ async fn main() -> Result<(), Error> {
         "Current BTC balance: {} satoshi",
         current_btc_balance.confirmed
     );
-    let current_eth_balance = eth_wallet.balance().await?;
+    let current_eth_balance = eth_wallet.balance(&eth_blockchain_client).await?;
     println!(
         "Current ETH balance: {} ETH ({} wei)",
         current_eth_balance.eth(),

--- a/walletd/src/lib.rs
+++ b/walletd/src/lib.rs
@@ -74,7 +74,8 @@
 //!
 //! let mut btc_wallet = BitcoinWalletBuilder::new().mnemonic(mnemonic.clone()).network_type(Network::Testnet).build().unwrap();
 //! let mut eth_wallet = EthereumWalletBuilder::new().mnemonic(mnemonic).network_type(HDNetworkType::TestNet).build().unwrap();
-//! eth_wallet.set_blockchain_client(EthClient::new("https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161")?);
+//! let ethclient_url = "https://goerli.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161";
+//! let _eth_client = EthClient::new(ethclient_url)?;
 //!
 //! # Ok(())
 //! # }


### PR DESCRIPTION
Moved the blockchain connector out of the eth wallet object. this allows the wallet object to remain immutable and clearer usage of the provider. 

future steps will be to unfold this further and path ethers directly or just the provider needed to connect to a blockchain

this now aligns more with the bitcoin wallet usage