### PR TITLE
chore: ignore ide files and codecov

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Cargo.lock
 **/cargo-test*.profraw
 **/*.rs.bk
+**/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/.DS_Store
 **/target
 Cargo.lock
-**/cargo-test*.profraw
 **/*.rs.bk
 **/.idea
+**/*.profraw


### PR DESCRIPTION
Quick PR to remove the inclusion of .idea files for IntelliJ code editors like Rust Rover or CLion.
Removed profraw file that was committed and added to gitignore so that no profraw files will be committed in future. these are for codecov and are usually uploaded and not stored in version control.