### PR TITLE
Fix Clippy lints to restore CI on Rust 1.95

### DIFF
--- a/coins/ethereum/src/ethereum_wallet.rs
+++ b/coins/ethereum/src/ethereum_wallet.rs
@@ -186,7 +186,7 @@ impl EthereumWallet {
     ///  Returns the balance for this Ethereum Wallet.
     pub async fn balance(&self, provider: &Provider<Http>) -> Result<EthereumAmount, Error> {
         let address = ethers::types::Address::from_str(&self.public_address())
-            .map_err(|e| (Error::FromStr(e.to_string())))?;
+            .map_err(|e| Error::FromStr(e.to_string()))?;
         let balance = EthClient::balance(provider, address).await?;
         Ok(balance)
     }

--- a/coins/monero/src/rct_types.rs
+++ b/coins/monero/src/rct_types.rs
@@ -701,7 +701,7 @@ impl BulletproofPlus {
     }
 
     fn hadamard_fold(v: &mut Vec<EdwardsPoint>, a: Scalar, b: Scalar) {
-        assert!(v.len() % 2 == 0, "Vector size should be even");
+        assert!(v.len().is_multiple_of(2), "Vector size should be even");
         let sz = v.len() / 2;
         let mut res = vec![EdwardsPoint::identity(); sz];
         for n in 0..sz {

--- a/mnemonics/monero/src/mnemonic.rs
+++ b/mnemonics/monero/src/mnemonic.rs
@@ -236,7 +236,7 @@ impl Mnemonic {
     /// valid mnemonic type length
     fn bytes_to_words(entropy_bytes: &[u8], wordlist_info: &WordList) -> Result<String, Error> {
         let wordlist = &wordlist_info.inner();
-        if entropy_bytes.len() % 4 != 0 || entropy_bytes.is_empty() {
+        if !entropy_bytes.len().is_multiple_of(4) || entropy_bytes.is_empty() {
             return Err(Error::ErrorInBytes(
                 "Length of secret_bytes must be greater than 0 and divisible by 4".into(),
             ));


### PR DESCRIPTION
## Summary

Three small, targeted fixes that bring CI back to green on the latest stable Rust (1.95.0). Each commit addresses one Clippy lint that became active between when main was last pushed (Sep 2025) and now. No behavior changes anywhere — pure lint compliance.

## Commits

1. `coins/ethereum/src/ethereum_wallet.rs:189` — remove redundant parens around closure body (`unused_parens`)
2. `mnemonics/monero/src/mnemonic.rs:239` — replace `x % 4` inequality with the negated `is_multiple_of(4)` call (`manual_is_multiple_of`, stabilized in Rust 1.95)
3. `coins/monero/src/rct_types.rs:704` — same lint, different file: `x % 2 == 0` becomes `x.is_multiple_of(2)`

## Verification

- Local: `cargo clippy --workspace --all-targets -- -D warnings` passes (modulo a Mac-only hedera-proto build script issue unrelated to this PR)
- CI on this branch: Clippy green, Build docs green, Build green, Run all tests green

## Not included

- The 5 Dependabot advisories (2 moderate, 3 low) on main. Those deserve their own PR(s).
- SECURITY.md (already prepared on a separate branch; will open after this lands so it goes in clean)
